### PR TITLE
Feat/create more space

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -77,10 +77,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "ladybug:build:production"
+              "buildTarget": "ladybug:build:production"
             },
             "development": {
-              "browserTarget": "ladybug:build:development",
+              "buildTarget": "ladybug:build:development",
               "proxyConfig": "src/proxy.conf.json"
             }
           },
@@ -92,7 +92,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "ladybug:build"
+            "buildTarget": "ladybug:build"
           }
         },
         "test": {

--- a/cypress/e2e/copying.cy.js
+++ b/cypress/e2e/copying.cy.js
@@ -1,39 +1,51 @@
-describe('Tests about copying', function() {
+describe("Tests about copying", function () {
   beforeEach(() => {
     cy.clearDebugStore();
-  })
-
-  afterEach(() => {
-    cy.get('li#testTab').click();
-    cy.get('#SelectAllButton').click();
-    cy.get('.row #DeleteSelectedButton').click();
-    cy.get('#confirmDeletion').click();
-    cy.get('#debugTab').click();
   });
 
-  it('Copy report to test tab', () => {
-    cy.visit('');
-    cy.get('#testTab').click();
-    cy.get('#metadataTable tbody', {timeout: 10000}).find('tr').should('not.exist');
+  afterEach(() => {
+    cy.get("li#testTab").click();
+    cy.get("#SelectAllButton").click();
+    cy.get(".row #DeleteSelectedButton").click();
+    cy.get("#confirmDeletion").click();
+    cy.get("#debugTab").click();
+  });
+
+  it("Copy report to test tab", () => {
+    cy.visit("");
+    cy.get("#testTab").click();
+    cy.get("#metadataTable tbody", { timeout: 10000 })
+      .find("tr")
+      .should("not.exist");
     cy.createReport();
-    cy.get('#debugTab').click();
-    cy.get('#metadataTable tbody', {timeout: 10000}).find('tr').should('not.exist');
-    cy.get('.row #RefreshButton').click();
-    cy.get('#metadataTable tbody').find('tr').should('have.length', 1);
-    cy.get('button[id="SelectAllReportsButton"]').click();
+    cy.get("#debugTab").click();
+    cy.get("#metadataTable tbody", { timeout: 10000 })
+      .find("tr")
+      .should("not.exist");
+    cy.get(".row #RefreshButton").click();
+    cy.get("#metadataTable tbody").find("tr").should("have.length", 1);
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-    cy.get('button#CopyButton').click();
-    cy.get('li#testTab').click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+    cy.get("button#CopyButton").click();
+    cy.get("li#testTab").click();
     // We test that the user does not have to refresh here.
-    cy.get('tbody#testReports').find('tr').should('have.length', 1);
-    cy.get('tbody#testReports').find('tr').contains('/Simple report').should('have.length', 1);
-    cy.get('#debugTab').click();
-    cy.get('#metadataTable tbody', {timeout: 10000}).find('tr').should('have.length', 1);
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-    cy.get('li#testTab').click();
+    cy.get("tbody#testReports").find("tr").should("have.length", 1);
+    cy.get("tbody#testReports")
+      .find("tr")
+      .contains("/Simple report")
+      .should("have.length", 1);
+    cy.get("#debugTab").click();
+    cy.get("#metadataTable tbody", { timeout: 10000 })
+      .find("tr")
+      .should("have.length", 1);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+    cy.get("li#testTab").click();
     // Do not refresh. The test tab should have saved its state.
-    cy.get('tbody#testReports').find('tr').should('have.length', 1);
-    cy.get('tbody#testReports').find('tr').contains('/Simple report').should('have.length', 1);
+    cy.get("tbody#testReports").find("tr").should("have.length", 1);
+    cy.get("tbody#testReports")
+      .find("tr")
+      .contains("/Simple report")
+      .should("have.length", 1);
   });
 });

--- a/cypress/e2e/debug_aboutOpenedReports.cy.js
+++ b/cypress/e2e/debug_aboutOpenedReports.cy.js
@@ -1,37 +1,56 @@
-describe('About opened reports', function() {
+describe("About opened reports", function () {
   beforeEach(() => {
     cy.clearDebugStore();
     cy.createReport();
     cy.createOtherReport();
-    cy.visit('')
+    cy.visit("");
   });
 
-  it('Close one', function() {
-    cy.get('button[id="SelectAllReportsButton"]').click();
+  it("Close one", function () {
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
     // Each of the two reports has three lines.
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li > div').should('contain', 'Simple report');
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li > div:contains(Simple report)').first().selectIfNotSelected();
-    cy.get('#CloseButton').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 2);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li > div").should(
+      "contain",
+      "Simple report"
+    );
+    cy.get(
+      "#debug-tree .jqx-tree-dropdown-root > li > div:contains(Simple report)"
+    )
+      .first()
+      .selectIfNotSelected();
+    cy.get("#CloseButton").click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
     // nth-child has an 1-based index
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li > div').should('have.text', 'Another simple report').click();
-    cy.get('#CloseButton').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li > div")
+      .should("have.text", "Another simple report")
+      .click();
+    cy.get("#CloseButton").click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 0);
   });
 
-  it('Close all', function() {
-    cy.get('.table-responsive tbody tr td:contains(Simple report)').first().click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-    cy.get('.table-responsive tbody tr td:contains("Another simple report")').first().click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
+  it("Close all", function () {
+    cy.get(".table-responsive tbody tr td:contains(Simple report)")
+      .first()
+      .click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+    cy.get('.table-responsive tbody tr td:contains("Another simple report")')
+      .first()
+      .click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 2);
     // Check sequence of opened reports. We expect "Simple report" first, then "Another simple report".
-    cy.get('#debug-tree .jqx-tree-dropdown-root li:nth-child(1) > div').should('contain', 'Simple report');
-    cy.get('#debug-tree .jqx-tree-dropdown-root li:nth-child(2) > div').should('have.text', 'Another simple report');
+    cy.get("#debug-tree .jqx-tree-dropdown-root li:nth-child(1) > div").should(
+      "contain",
+      "Simple report"
+    );
+    cy.get("#debug-tree .jqx-tree-dropdown-root li:nth-child(2) > div").should(
+      "have.text",
+      "Another simple report"
+    );
     cy.get('button[id="CloseAllButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-  })
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 0);
+  });
 
   // // TODO: This can not be tested easily atm, since only the css is changed on expand and collapse
   // it('Expand and collapse', function() {
@@ -80,77 +99,95 @@ describe('About opened reports', function() {
 
 function linesFormExpandedNode($lines, evenOrOdd) {
   const startIcon = `assets/tree-icons/startpoint-${evenOrOdd}.gif`;
-  const oddOrEven = (evenOrOdd == 'even') ? 'odd' : 'even';
+  const oddOrEven = evenOrOdd == "even" ? "odd" : "even";
   const endIcon = `assets/tree-icons/endpoint-${oddOrEven}.gif`;
   expect($lines).to.have.length(3);
   expect($lines.eq(0).children()).to.have.length(2);
-  expect($lines.eq(0).children().eq(0)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(0).children().eq(0)).to.have.class('expand-icon');
-  expect($lines.eq(0).children().eq(0)).to.have.class('fa-minus');
-  expect($lines.eq(0).children().eq(1)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(0).children().eq(1)).to.have.class('node-icon');
-  expect($lines.eq(0).children('img')).to.have.length(0);
+  expect($lines.eq(0).children().eq(0)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(0).children().eq(0)).to.have.class("expand-icon");
+  expect($lines.eq(0).children().eq(0)).to.have.class("fa-minus");
+  expect($lines.eq(0).children().eq(1)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(0).children().eq(1)).to.have.class("node-icon");
+  expect($lines.eq(0).children("img")).to.have.length(0);
   expect($lines.eq(1).children()).to.have.length(4);
-  expect($lines.eq(1).children().eq(0)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(1).children().eq(1)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(1).children().eq(2)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(1).children().eq(3)).to.have.prop('nodeName', 'IMG');
-  expect($lines.eq(1).children().eq(0)).to.have.class('indent');
-  expect($lines.eq(1).children().eq(1)).to.have.class('expand-icon');
-  expect($lines.eq(1).children().eq(1)).to.have.class('fa-minus');
-  expect($lines.eq(1).children().eq(2)).to.have.class('node-icon');
-  expect($lines.eq(1).children().eq(3).attr('src')).to.equal(startIcon);
+  expect($lines.eq(1).children().eq(0)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(1).children().eq(1)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(1).children().eq(2)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(1).children().eq(3)).to.have.prop("nodeName", "IMG");
+  expect($lines.eq(1).children().eq(0)).to.have.class("indent");
+  expect($lines.eq(1).children().eq(1)).to.have.class("expand-icon");
+  expect($lines.eq(1).children().eq(1)).to.have.class("fa-minus");
+  expect($lines.eq(1).children().eq(2)).to.have.class("node-icon");
+  expect($lines.eq(1).children().eq(3).attr("src")).to.equal(startIcon);
   expect($lines.eq(2).children()).to.have.length(5);
-  expect($lines.eq(2).children().eq(0)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(2).children().eq(1)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(2).children().eq(2)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(2).children().eq(3)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(2).children().eq(4)).to.have.prop('nodeName', 'IMG');
-  expect($lines.eq(2).children().eq(0)).to.have.class('indent');
-  expect($lines.eq(2).children().eq(1)).to.have.class('indent');
-  expect($lines.eq(2).children().eq(2)).to.have.class('glyphicon');
-  expect($lines.eq(2).children().eq(3)).to.have.class('node-icon');
-  expect($lines.eq(2).children().eq(4).attr('src')).to.equal(endIcon);
-};
+  expect($lines.eq(2).children().eq(0)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(2).children().eq(1)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(2).children().eq(2)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(2).children().eq(3)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(2).children().eq(4)).to.have.prop("nodeName", "IMG");
+  expect($lines.eq(2).children().eq(0)).to.have.class("indent");
+  expect($lines.eq(2).children().eq(1)).to.have.class("indent");
+  expect($lines.eq(2).children().eq(2)).to.have.class("glyphicon");
+  expect($lines.eq(2).children().eq(3)).to.have.class("node-icon");
+  expect($lines.eq(2).children().eq(4).attr("src")).to.equal(endIcon);
+}
 
 function linesFormCollapsedNode($lines) {
   expect($lines).to.have.length(1);
   expect($lines.eq(0).children()).to.have.length(2);
-  expect($lines.eq(0).children().eq(0)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(0).children().eq(1)).to.have.prop('nodeName', 'SPAN');
-  expect($lines.eq(0).children().eq(0)).to.have.class('expand-icon');
-  expect($lines.eq(0).children().eq(0)).to.have.class('fa-plus');
-  expect($lines.eq(0).children().eq(1)).to.have.class('node-icon');
+  expect($lines.eq(0).children().eq(0)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(0).children().eq(1)).to.have.prop("nodeName", "SPAN");
+  expect($lines.eq(0).children().eq(0)).to.have.class("expand-icon");
+  expect($lines.eq(0).children().eq(0)).to.have.class("fa-plus");
+  expect($lines.eq(0).children().eq(1)).to.have.class("node-icon");
 }
 
 function checkNodeInfo(name) {
   cy.get(`.jqx-tree-dropdown-root > li:contains(${name}):eq(0)`).click();
-  const startOfReportTag = '<Report';
-  const wordsInName = name.split(' ');
-  const quotedWordsInName = wordsInName.map(word => '"' + word + '"');
-  cy.getShownMonacoModelElement().within(function(shownMonacoElement) {
+  const startOfReportTag = "<Report";
+  const wordsInName = name.split(" ");
+  const quotedWordsInName = wordsInName.map((word) => '"' + word + '"');
+  cy.getShownMonacoModelElement().within(function (shownMonacoElement) {
     cy.wrap(shownMonacoElement).find(`span:contains(${startOfReportTag})`);
-    cy.wrap(shownMonacoElement).find('span:contains(Name)');
-    quotedWordsInName.forEach(word => {
+    cy.wrap(shownMonacoElement).find("span:contains(Name)");
+    quotedWordsInName.forEach((word) => {
       cy.wrap(shownMonacoElement).find(`span:contains(${word})`);
     });
   });
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(0)').should('have.text', 'Name');
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(1)').should('have.text', `${name}`);
-  cy.get('#displayedNodeTable tr:eq(4) td:eq(0)').should('have.text', 'StorageId');
-  cy.get('#displayedNodeTable tr:eq(4) td:eq(1)').should('not.be.empty');
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(0)").should("have.text", "Name");
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(1)").should(
+    "have.text",
+    `${name}`
+  );
+  cy.get("#displayedNodeTable tr:eq(4) td:eq(0)").should(
+    "have.text",
+    "StorageId"
+  );
+  cy.get("#displayedNodeTable tr:eq(4) td:eq(1)").should("not.be.empty");
   cy.get(`div.treeview > ul > li:contains(${name}):eq(1)`).click();
   const helloWorld = "Hello\xa0World!";
   cy.getShownMonacoModelElement().find(`span:contains(${helloWorld})`);
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(0)').should('have.text', 'Name');
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(1)').should('have.text', `${name}`);
-  cy.get('#displayedNodeTable tr:eq(5) td:eq(0)').should('have.text', 'CheckpointUID');
-  cy.get('#displayedNodeTable tr:eq(5) td:eq(1)').should('not.be.empty');
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(0)").should("have.text", "Name");
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(1)").should(
+    "have.text",
+    `${name}`
+  );
+  cy.get("#displayedNodeTable tr:eq(5) td:eq(0)").should(
+    "have.text",
+    "CheckpointUID"
+  );
+  cy.get("#displayedNodeTable tr:eq(5) td:eq(1)").should("not.be.empty");
   cy.get(`div.treeview > ul > li:contains(${name}):eq(2)`).click();
   const goodbyeWorld = "Goodbye\xa0World!";
   cy.getShownMonacoModelElement().find(`span:contains(${goodbyeWorld})`);
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(0)').should('have.text', 'Name');
-  cy.get('#displayedNodeTable tr:eq(0) td:eq(1)').should('have.text', `${name}`);
-  cy.get('#displayedNodeTable tr:eq(5) td:eq(0)').should('have.text', 'CheckpointUID');
-  cy.get('#displayedNodeTable tr:eq(5) td:eq(1)').should('not.be.empty');
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(0)").should("have.text", "Name");
+  cy.get("#displayedNodeTable tr:eq(0) td:eq(1)").should(
+    "have.text",
+    `${name}`
+  );
+  cy.get("#displayedNodeTable tr:eq(5) td:eq(0)").should(
+    "have.text",
+    "CheckpointUID"
+  );
+  cy.get("#displayedNodeTable tr:eq(5) td:eq(1)").should("not.be.empty");
 }

--- a/cypress/e2e/debug_download.cy.js
+++ b/cypress/e2e/debug_download.cy.js
@@ -1,11 +1,11 @@
-const path = require('path');
+const path = require("path");
 
-describe('Debug tab download', function() {
+describe("Debug tab download", function () {
   beforeEach(() => {
     cy.clearDebugStore();
     cy.createReport();
     cy.createOtherReport();
-    cy.visit('');
+    cy.visit("");
     cy.wait(500);
   });
 
@@ -19,156 +19,226 @@ describe('Debug tab download', function() {
     // We cannot do this by setting Cypress setting "trashAssetsBeforeRuns" to "true".
     // That would also delete downloads/.gitignore, which is not what we want.
     // The 'deleteDownloads' task skips .gitignore.
-    const downloadsFolder = Cypress.config('downloadsFolder');
-    cy.task('deleteDownloads', {downloadsPath: downloadsFolder, fileSep: Cypress.env('FILESEP')});
+    const downloadsFolder = Cypress.config("downloadsFolder");
+    cy.task("deleteDownloads", {
+      downloadsPath: downloadsFolder,
+      fileSep: Cypress.env("FILESEP"),
+    });
   });
 
   // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
-  xit('Download and upload table', function() {
-    const downloadsFolder = Cypress.config('downloadsFolder');
-    cy.task('downloads', downloadsFolder).then(filesBefore => {
-      cy.get('.table-responsive table tbody').find('tr').should('have.length', 2);
-      cy.get('#dropdownDownloadTable').click();
-      cy.get('#tableContent').find('button:contains("XML & Binary")[class="dropdown-item"]').click();
+  xit("Download and upload table", function () {
+    const downloadsFolder = Cypress.config("downloadsFolder");
+    cy.task("downloads", downloadsFolder).then((filesBefore) => {
+      cy.get(".table-responsive table tbody")
+        .find("tr")
+        .should("have.length", 2);
+      cy.get("#dropdownDownloadTable").click();
+      cy.get("#tableContent")
+        .find('button:contains("XML & Binary")[class="dropdown-item"]')
+        .click();
       cy.waitForNumFiles(downloadsFolder, filesBefore.length + 1);
-      cy.task('downloads', downloadsFolder).then(filesAfter => {
-        const newFile = filesAfter.filter(file => !filesBefore.includes(file))[0];
-        expect(newFile).to.contain('Ladybug Debug');
-        expect(newFile).to.contain('2 reports');
-        cy.readFile(cy.functions.downloadPath(newFile), 'binary', {timeout: 15000})
-        .should(buffer => expect(buffer.length).to.be.gt(10)).then(buffer => {
-          cy.log(`Number of read bytes: ${buffer.length}`);
-        });
-        cy.clearDebugStore();
-        cy.get('#RefreshButton').click();
-        cy.wait(100);
-        cy.get('.table-responsive tbody').find('tr').should('not.exist');
-        cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-        cy.readFile(cy.functions.downloadPath(newFile), 'binary')
-        .then((rawContent) => {
-          console.log(`Have content of uploaded file, length ${rawContent.length}`);
-          return Cypress.Blob.binaryStringToBlob(rawContent);
+      cy.task("downloads", downloadsFolder).then((filesAfter) => {
+        const newFile = filesAfter.filter(
+          (file) => !filesBefore.includes(file)
+        )[0];
+        expect(newFile).to.contain("Ladybug Debug");
+        expect(newFile).to.contain("2 reports");
+        cy.readFile(cy.functions.downloadPath(newFile), "binary", {
+          timeout: 15000,
         })
-        .then(fileContent => {
-          console.log(`Have transformed content length ${fileContent.length}`);
-          cy.get('input#uploadFileTable').attachFile({
-            fileContent,
-            fileName: newFile
+          .should((buffer) => expect(buffer.length).to.be.gt(10))
+          .then((buffer) => {
+            cy.log(`Number of read bytes: ${buffer.length}`);
           });
-        });
-        cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-        cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
+        cy.clearDebugStore();
+        cy.get("#RefreshButton").click();
+        cy.wait(100);
+        cy.get(".table-responsive tbody").find("tr").should("not.exist");
+        cy.get("#debug-tree .jqx-tree-dropdown-root > li").should(
+          "have.length",
+          0
+        );
+        cy.readFile(cy.functions.downloadPath(newFile), "binary")
+          .then((rawContent) => {
+            console.log(
+              `Have content of uploaded file, length ${rawContent.length}`
+            );
+            return Cypress.Blob.binaryStringToBlob(rawContent);
+          })
+          .then((fileContent) => {
+            console.log(
+              `Have transformed content length ${fileContent.length}`
+            );
+            cy.get("input#uploadFileTable").attachFile({
+              fileContent,
+              fileName: newFile,
+            });
+          });
+        cy.get("#debug-tree .jqx-tree-dropdown-root > li").should(
+          "have.length",
+          0
+        );
+        cy.get("#debug-tree .jqx-tree-dropdown-root > li").should(
+          "have.length",
+          2
+        );
       });
     });
   });
 
   // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
-  xit('Download all open reports', function() {
-    const downloadsFolder = Cypress.config('downloadsFolder');
-    cy.get('.table-responsive tbody').find('tr').should('have.length', 2);
-    cy.get('button[id="SelectAllReportsButton"]').click();
+  xit("Download all open reports", function () {
+    const downloadsFolder = Cypress.config("downloadsFolder");
+    cy.get(".table-responsive tbody").find("tr").should("have.length", 2);
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)').should('have.length', 1)
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)').should('have.length', 1);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 2);
+    cy.get(
+      "#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)"
+    ).should("have.length", 1);
+    cy.get(
+      "#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)"
+    ).should("have.length", 1);
     // Debug store should not be cleared, because the report being downloaded
     // is requested here from the backend. The backend should still have the
     // report to have a valid test.
-    cy.task('downloads', downloadsFolder).should('have.length.at.least', 0).then(filesBefore => {
-      cy.get('#dropdownDownloadTree').click();
-      cy.get('#treeButtons button:contains("XML & Binary")[class="dropdown-item"]').click();
-      cy.waitForNumFiles(downloadsFolder, filesBefore.length + 1);
-      cy.task('downloads', downloadsFolder).then(filesAfter => {
-        const newFile = filesAfter.filter(file => !filesBefore.includes(file))[0];
-        expect(newFile).to.contain('Ladybug Debug');
-        expect(newFile).to.contain('2 reports');
-        cy.readFile(cy.functions.downloadPath(newFile), 'binary', {timeout: 15000})
-        .should(buffer => expect(buffer.length).to.be.gt(10)).then(buffer => {
-          cy.log(`Number of read bytes: ${buffer.length}`);
-        });
-        cy.get('button[id="CloseAllButton"]').click();
-        cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-        cy.readFile(cy.functions.downloadPath(newFile), 'binary')
-        .then(Cypress.Blob.binaryStringToBlob)
-        .then(fileContent => {
-          cy.get('input#uploadFileTable').attachFile({
-            fileContent,
-            fileName: newFile
-          });
+    cy.task("downloads", downloadsFolder)
+      .should("have.length.at.least", 0)
+      .then((filesBefore) => {
+        cy.get("#dropdownDownloadTree").click();
+        cy.get(
+          '#treeButtons button:contains("XML & Binary")[class="dropdown-item"]'
+        ).click();
+        cy.waitForNumFiles(downloadsFolder, filesBefore.length + 1);
+        cy.task("downloads", downloadsFolder).then((filesAfter) => {
+          const newFile = filesAfter.filter(
+            (file) => !filesBefore.includes(file)
+          )[0];
+          expect(newFile).to.contain("Ladybug Debug");
+          expect(newFile).to.contain("2 reports");
+          cy.readFile(cy.functions.downloadPath(newFile), "binary", {
+            timeout: 15000,
+          })
+            .should((buffer) => expect(buffer.length).to.be.gt(10))
+            .then((buffer) => {
+              cy.log(`Number of read bytes: ${buffer.length}`);
+            });
+          cy.get('button[id="CloseAllButton"]').click();
+          cy.get("#debug-tree .jqx-tree-dropdown-root > li").should(
+            "have.length",
+            0
+          );
+          cy.readFile(cy.functions.downloadPath(newFile), "binary")
+            .then(Cypress.Blob.binaryStringToBlob)
+            .then((fileContent) => {
+              cy.get("input#uploadFileTable").attachFile({
+                fileContent,
+                fileName: newFile,
+              });
+            });
         });
       });
-    });
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)').should('have.length', 1)
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)').should('have.length', 1);
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 2);
+    cy.get(
+      "#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)"
+    ).should("have.length", 1);
+    cy.get(
+      "#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)"
+    ).should("have.length", 1);
   });
 
   // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
-  xit('Download displayed report, from root node', function() {
+  xit("Download displayed report, from root node", function () {
     testDownloadFromNode(0);
   });
 
   // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
-  xit('Download displayed report, from start node', function() {
+  xit("Download displayed report, from start node", function () {
     testDownloadFromNode(1);
   });
 
   // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
-  xit('Download displayed report, from end node', function() {
+  xit("Download displayed report, from end node", function () {
     testDownloadFromNode(2);
   });
 });
 
 function testDownloadFromNode(nodeNum) {
-  const downloadsFolder = Cypress.config('downloadsFolder');
+  const downloadsFolder = Cypress.config("downloadsFolder");
   cy.wait(100);
-  cy.get('.table-responsive tbody').find('tr').should('have.length', 2);
-  cy.get('button[id="SelectAllReportsButton"]').click();
-    cy.get('button[id="OpenSelectedReportsButton"]').click();
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 2);
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)').should('have.length', 1)
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)').should('have.length', 1);
+  cy.get(".table-responsive tbody").find("tr").should("have.length", 2);
+  cy.get("[data-cy-select-all-reports]").click();
+  cy.get('button[id="OpenSelectedReportsButton"]').click();
+  cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 2);
+  cy.get(
+    "#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report)"
+  ).should("have.length", 1);
+  cy.get(
+    "#debug-tree .jqx-tree-dropdown-root > li:contains(Another simple report)"
+  ).should("have.length", 1);
   // Debug store should not be cleared, because the report being downloaded
   // is requested here from the backend. The backend should still have the
   // report to have a valid test.
   //
   // We can not click the node to select it because it is selected already.
   // If we click, we unselect it and then no node is selected anymore.
-  let string = '';
+  let string = "";
   for (let i = 0; i < nodeNum; i++) {
-    string += '> ul > li'
+    string += "> ul > li";
   }
-  cy.wait(100)
-  cy.get(`.jqx-tree-dropdown-root > li:contains(Simple report):not(li:contains(Another))` + string + ' > div').click();
-  cy.task('downloads', downloadsFolder).should('have.length', 1).then(filesBefore => {
-    cy.get('#dropdownDownloadDisplay').click();
-    cy.get('#displayButtons button:contains("Binary"):not(:contains("XML"))[class="dropdown-item"]').click();
-    cy.waitForNumFiles(downloadsFolder, filesBefore.length + 1);
-    cy.task('downloads', downloadsFolder).then(filesAfter => {
-      const newFile = filesAfter.filter(file => !filesBefore.includes(file))[0];
-      expect(newFile).to.contain('Simple report.ttr');
-      expect(newFile).not.to.contain('other');
-      cy.readFile(cy.functions.downloadPath(newFile), 'binary', {timeout: 15000})
-      .should(buffer => expect(buffer.length).to.be.gt(10)).then(buffer => {
-        cy.log(`Number of read bytes: ${buffer.length}`);
-      });
-      cy.get('button[id="CloseAllButton"]').click();
-      cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-      cy.readFile(cy.functions.downloadPath(newFile), 'binary')
-      .then(Cypress.Blob.binaryStringToBlob)
-      .then(fileContent => {
-        cy.get('input#uploadFileTable').attachFile({
-          fileContent,
-          fileName: newFile
-        });
+  cy.wait(100);
+  cy.get(
+    `.jqx-tree-dropdown-root > li:contains(Simple report):not(li:contains(Another))` +
+      string +
+      " > div"
+  ).click();
+  cy.task("downloads", downloadsFolder)
+    .should("have.length", 1)
+    .then((filesBefore) => {
+      cy.get("#dropdownDownloadDisplay").click();
+      cy.get(
+        '#displayButtons button:contains("Binary"):not(:contains("XML"))[class="dropdown-item"]'
+      ).click();
+      cy.waitForNumFiles(downloadsFolder, filesBefore.length + 1);
+      cy.task("downloads", downloadsFolder).then((filesAfter) => {
+        const newFile = filesAfter.filter(
+          (file) => !filesBefore.includes(file)
+        )[0];
+        expect(newFile).to.contain("Simple report.ttr");
+        expect(newFile).not.to.contain("other");
+        cy.readFile(cy.functions.downloadPath(newFile), "binary", {
+          timeout: 15000,
+        })
+          .should((buffer) => expect(buffer.length).to.be.gt(10))
+          .then((buffer) => {
+            cy.log(`Number of read bytes: ${buffer.length}`);
+          });
+        cy.get('button[id="CloseAllButton"]').click();
+        cy.get("#debug-tree .jqx-tree-dropdown-root > li").should(
+          "have.length",
+          0
+        );
+        cy.readFile(cy.functions.downloadPath(newFile), "binary")
+          .then(Cypress.Blob.binaryStringToBlob)
+          .then((fileContent) => {
+            cy.get("input#uploadFileTable").attachFile({
+              fileContent,
+              fileName: newFile,
+            });
+          });
       });
     });
-  });
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li', {timeout: 10000}).should('have.length', 1);
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report):not(:contains(other))').should('have.length', 1)
+  cy.get("#debug-tree .jqx-tree-dropdown-root > li", { timeout: 10000 }).should(
+    "have.length",
+    1
+  );
+  cy.get(
+    "#debug-tree .jqx-tree-dropdown-root > li:contains(Simple report):not(:contains(other))"
+  ).should("have.length", 1);
 }

--- a/cypress/e2e/debug_labels.cy.js
+++ b/cypress/e2e/debug_labels.cy.js
@@ -1,45 +1,62 @@
-describe('Test labels', function() {
+describe("Test labels", function () {
   beforeEach(() => {
     cy.clearDebugStore();
-  })
+  });
 
-  afterEach(function() {
+  afterEach(function () {
     cy.get('button[id="CloseAllButton"]').click();
   });
 
-  it('Test label null', function() {
+  it("Test label null", function () {
     cy.createReportWithLabelNull();
-    cy.visit('');
-    cy.get('button[id="SelectAllReportsButton"]').click();
+    cy.visit("");
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-    testTreeView('Message is null', 'Null String');
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+    testTreeView("Message is null", "Null String");
   });
 
-  it('Test label empty string', function() {
+  it("Test label empty string", function () {
     cy.createReportWithLabelEmpty();
-    cy.visit('');
-    cy.get('button[id="SelectAllReportsButton"]').click();
+    cy.visit("");
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-    testTreeView('Message is an empty string', 'Empty String');
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+    testTreeView("Message is an empty string", "Empty String");
   });
 });
 
 function testTreeView(reportName, labelString) {
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li > div').within(function($node) {
+  cy.get("#debug-tree .jqx-tree-dropdown-root > li > div").within(function (
+    $node
+  ) {
     cy.wrap($node).contains(reportName);
   });
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li > ul > li > div').within(function($node) {
-    cy.wrap($node).should('contain', reportName);
-    cy.wrap($node).find('img').invoke('attr', 'src').should('eq', 'assets/tree-icons/startpoint-even.gif');
+  cy.get("#debug-tree .jqx-tree-dropdown-root > li > ul > li > div").within(
+    function ($node) {
+      cy.wrap($node).should("contain", reportName);
+      cy.wrap($node)
+        .find("img")
+        .invoke("attr", "src")
+        .should("eq", "assets/tree-icons/startpoint-even.gif");
+    }
+  );
+  cy.get(
+    "#debug-tree .jqx-tree-dropdown-root > li > ul > li > ul > li:nth-child(1) > div"
+  ).within(function ($node) {
+    cy.wrap($node).should("have.text", labelString);
+    cy.wrap($node)
+      .find("img")
+      .invoke("attr", "src")
+      .should("eq", "assets/tree-icons/infopoint-odd.gif");
   });
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li > ul > li > ul > li:nth-child(1) > div').within(function($node) {
-    cy.wrap($node).should('have.text', labelString);
-    cy.wrap($node).find('img').invoke('attr', 'src').should('eq', 'assets/tree-icons/infopoint-odd.gif');
-  });
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li > ul > li > ul > li:nth-child(2) > div').within(function($node) {
-    cy.wrap($node).should('have.text', reportName);
-    cy.wrap($node).find('img').invoke('attr', 'src').should('eq', 'assets/tree-icons/endpoint-odd.gif');
+  cy.get(
+    "#debug-tree .jqx-tree-dropdown-root > li > ul > li > ul > li:nth-child(2) > div"
+  ).within(function ($node) {
+    cy.wrap($node).should("have.text", reportName);
+    cy.wrap($node)
+      .find("img")
+      .invoke("attr", "src")
+      .should("eq", "assets/tree-icons/endpoint-odd.gif");
   });
 }

--- a/cypress/e2e/debug_labels.cy.js
+++ b/cypress/e2e/debug_labels.cy.js
@@ -12,6 +12,7 @@ describe("Test labels", function () {
     cy.visit("");
     cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
+    cy.wait(300);
     cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
     testTreeView("Message is null", "Null String");
   });

--- a/cypress/e2e/testtab.cy.js
+++ b/cypress/e2e/testtab.cy.js
@@ -167,7 +167,7 @@ describe("About the Test tab", function () {
 });
 
 function copyTheReportsToTestTab() {
-  cy.get('button[id="SelectAllReportsButton"]').click();
+  cy.get("[data-cy-select-all-reports]").click();
   cy.get('button[id="OpenSelectedReportsButton"]').click();
   // We test many times already that opening two reports yields six nodes.
   // Adding the test here again has another purpose. We want the DOM to

--- a/cypress/e2e/testtab_edit.cy.js
+++ b/cypress/e2e/testtab_edit.cy.js
@@ -1,105 +1,122 @@
-import chaiColors from 'chai-colors'
-chai.use(chaiColors)
+import chaiColors from "chai-colors";
 
-describe('Edit tests', function() {
+chai.use(chaiColors);
+
+describe("Edit tests", function () {
   beforeEach(() => {
     cy.clearDebugStore();
-  })
+  });
 
-  afterEach(function() {
+  afterEach(function () {
     cy.clearDebugStore();
-    cy.get('li#debugTab a').click();
-    cy.get('li#debugTab a:eq(0)').should('have.class', 'active');
+    cy.get("li#debugTab a").click();
+    cy.get("li#debugTab a:eq(0)").should("have.class", "active");
     // Wait for debug tab to be rendered
     cy.wait(1000);
     cy.get('button[id="CloseAllButton"]').click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 0);
-    cy.get('li#testTab').click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 0);
+    cy.get("li#testTab").click();
     // Give UI time to build up the test tab.
     cy.wait(1000);
-    cy.get('#SelectAllButton').click();
-    cy.get('#DeleteSelectedButton').click();
-    cy.get('#confirmDeletion').click();
-    cy.get('#testReports tr', {timeout: 10000}).should('have.length', 0);
-    cy.get('li#debugTab').click();
+    cy.get("#SelectAllButton").click();
+    cy.get("#DeleteSelectedButton").click();
+    cy.get("#confirmDeletion").click();
+    cy.get("#testReports tr", { timeout: 10000 }).should("have.length", 0);
+    cy.get("li#debugTab").click();
   });
 
-  it('Edit report in test tab', function() {
+  it("Edit report in test tab", function () {
     prepareEdit();
-    cy.get('.report-tab .jqx-tree-dropdown-root > li > ul > li > div').click();
+    cy.get(".report-tab .jqx-tree-dropdown-root > li > ul > li > div").click();
     cy.wait(1000);
-    cy.get('#EditButton').click();
+    cy.get("#EditButton").click();
     cy.wait(1000);
     // According to https://stackoverflow.com/questions/56617522/testing-monaco-editor-with-cypress
-    cy.get('.report-tab #editor').click().focused().type('{ctrl}a').type('Hello Original World!');
-    cy.get('#SaveButton').click()
-    cy.get('.modal-title').should('include.text', 'Are you sure');
-    cy.get('.col:not(.text-right)').contains('Hello World!');
-    cy.get('.col.text-right').contains('Hello Original World!');
-    cy.get('button:contains(Yes)').click();
+    cy.get(".report-tab #editor")
+      .click()
+      .focused()
+      .type("{ctrl}a")
+      .type("Hello Original World!");
+    cy.get("#SaveButton").click();
+    cy.get(".modal-title").should("include.text", "Are you sure");
+    cy.get(".col:not(.text-right)").contains("Hello World!");
+    cy.get(".col.text-right").contains("Hello Original World!");
+    cy.get("button:contains(Yes)").click();
     cy.wait(1000);
-    cy.get('.report-tab .jqx-tree-dropdown-root > li > ul > li > ul > li > div').click()
+    cy.get(
+      ".report-tab .jqx-tree-dropdown-root > li > ul > li > ul > li > div"
+    ).click();
     cy.wait(1000);
-    cy.get('#EditButton').click();
+    cy.get("#EditButton").click();
     cy.wait(1000);
-    cy.get('.report-tab #editor').click().focused().type('{ctrl}a').type('Goodbye Original World!');
-    cy.get('#SaveButton').click()
-    cy.get('button:contains(Yes)').click();
-    cy.get('li#testTab').click();
-    cy.get('#RunreportButton').click();
+    cy.get(".report-tab #editor")
+      .click()
+      .focused()
+      .type("{ctrl}a")
+      .type("Goodbye Original World!");
+    cy.get("#SaveButton").click();
+    cy.get("button:contains(Yes)").click();
+    cy.get("li#testTab").click();
+    cy.get("#RunreportButton").click();
     // cy.get('span:contains(0/1 stubbed)').should('have.css', 'color').and('be.colored', 'green');
   });
 
-  it('Editing without pressing Edit produces error', function() {
+  it("Editing without pressing Edit produces error", function () {
     prepareEdit();
-    cy.get('.report-tab .jqx-tree-dropdown-root > li > ul > li > div').click();
+    cy.get(".report-tab .jqx-tree-dropdown-root > li > ul > li > div").click();
     cy.wait(1000);
     // Do not press Edit button
-    cy.get('#SaveButton').should('have.length', 0);
-    cy.get('.report-tab #editor').click().type('x');
-    cy.get('#readyOnlyLabel').contains('OFF');
-    cy.get('.message').should('have.length', 0);
+    cy.get("#SaveButton").should("have.length", 0);
+    cy.get(".report-tab #editor").click().type("x");
+    cy.get("#readyOnlyLabel").contains("OFF");
+    cy.get(".message").should("have.length", 0);
   });
 
-  it('When saving edit cancelled then original text kept and rerun fails', function() {
+  it("When saving edit cancelled then original text kept and rerun fails", function () {
     prepareEdit();
-    cy.get('.report-tab .jqx-tree-dropdown-root > li > ul > li > div').click();
+    cy.get(".report-tab .jqx-tree-dropdown-root > li > ul > li > div").click();
     cy.wait(1000);
-    cy.get('#EditButton').click();
-    cy.get('#readyOnlyLabel').contains('ON');
+    cy.get("#EditButton").click();
+    cy.get("#readyOnlyLabel").contains("ON");
     cy.wait(1000);
     // According to https://stackoverflow.com/questions/56617522/testing-monaco-editor-with-cypress
-    cy.get('.report-tab #editor').click().focused().type('{ctrl}a').type('Hello Original World!');
-    cy.get('#SaveButton').click();
-    cy.get('.modal-title').should('include.text', 'Are you sure');
-    cy.contains('Hello Original World!');
+    cy.get(".report-tab #editor")
+      .click()
+      .focused()
+      .type("{ctrl}a")
+      .type("Hello Original World!");
+    cy.get("#SaveButton").click();
+    cy.get(".modal-title").should("include.text", "Are you sure");
+    cy.contains("Hello Original World!");
     // Give dialog time to initialize
     cy.wait(1000);
-    cy.get('button:contains(No)').click();
-    cy.get('.modal-title').should('have.length', 0);
-    cy.get('#SaveButton').should('have.length', 1);
-    cy.contains('Hello Original World!');
-    cy.get('li#testTab').click();
-    cy.get('#RunreportButton').click();
+    cy.get("button:contains(No)").click();
+    cy.get(".modal-title").should("have.length", 0);
+    cy.get("#SaveButton").should("have.length", 1);
+    cy.contains("Hello Original World!");
+    cy.get("li#testTab").click();
+    cy.get("#RunreportButton").click();
     // cy.get('span:contains(0/1 stubbed)').should('have.css', 'color').and('be.colored', 'red');
   });
 });
 
 function prepareEdit() {
   cy.createReport();
-  cy.visit('');
+  cy.visit("");
   cy.wait(100);
-  cy.get('button[id="SelectAllReportsButton"]').click();
-    cy.get('button[id="OpenSelectedReportsButton"]').click();
-  cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
-  cy.get('button#CopyButton').click();
-  cy.get('li#testTab').click();
-  cy.get('#testReports tr').should('have.length', 1);
-  cy.get('#OpenreportButton').click();
+  cy.get("[data-cy-select-all-reports]").click();
+  cy.get('button[id="OpenSelectedReportsButton"]').click();
+  cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
+  cy.get("button#CopyButton").click();
+  cy.get("li#testTab").click();
+  cy.get("#testReports tr").should("have.length", 1);
+  cy.get("#OpenreportButton").click();
   // Martijn hopes this fixes an issue in Firefox. The test
   // should see that the fourth tab has caption "Simple report".
   cy.wait(1000);
-  cy.get('ul.nav-tabs li:nth-child(3)').find('a.active').should('include.text', 'Simple report');
+  cy.get("ul.nav-tabs li:nth-child(3)")
+    .find("a.active")
+    .should("include.text", "Simple report");
   // Wait until the tab has been rendered
-  cy.get('.report-tab .jqx-tree-dropdown-root > li').should('have.length', 1);
+  cy.get(".report-tab .jqx-tree-dropdown-root > li").should("have.length", 1);
 }

--- a/cypress/e2e/testtab_withOneReport.cy.js
+++ b/cypress/e2e/testtab_withOneReport.cy.js
@@ -7,7 +7,7 @@ describe("Tests with one report", function () {
     cy.clearDebugStore();
     cy.createReport();
     cy.visit("");
-    cy.get('button[id="SelectAllReportsButton"]').click();
+    cy.get("[data-cy-select-all-reports]").click();
     cy.get('button[id="OpenSelectedReportsButton"]').click();
     cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
     cy.get("button#CopyButton").click();

--- a/cypress/e2e/transformation.cy.js
+++ b/cypress/e2e/transformation.cy.js
@@ -1,37 +1,48 @@
-describe('Report transformation', function() {
+describe("Report transformation", () => {
   beforeEach(() => {
     cy.clearDebugStore();
-  })
+  });
 
-  afterEach(function() {
+  afterEach(() => {
     cy.clearDebugStore();
-    cy.get('#SettingsButton').click();
+    cy.get("#SettingsButton").click();
     // Factory reset in settings dialog. Resets
     // transformation to factory value.
     cy.get('button[title ^= "Reset and save factory settings"]').click();
-    cy.get('button[id=saveTableSettings]').click();
+    cy.get("button[id=saveTableSettings]").click();
   });
 
-  it('Update transformation', function() {
-    cy.visit('');
-    cy.get('#SettingsButton').click();
-    cy.get('textarea[formcontrolname=transformation]').type('{selectAll}');
-    cy.get('textarea[formcontrolname=transformation]').type('{del}');
-    cy.get('textarea[formcontrolname=transformation]').within((textArea) => {
-      cy.fixture('ignoreName.xslt').then((newText) => cy.wrap(textArea).type(newText));
+  it("Update transformation", function () {
+    cy.visit("");
+    cy.get("#SettingsButton").click();
+    cy.get("textarea[formcontrolname=transformation]").type("{selectAll}");
+    cy.get("textarea[formcontrolname=transformation]").type("{del}");
+    cy.get("textarea[formcontrolname=transformation]").within((textArea) => {
+      cy.fixture("ignoreName.xslt").then((newText) =>
+        cy.wrap(textArea).type(newText)
+      );
     });
-    cy.get('input[type=checkbox][formcontrolname=transformationEnabled]').check();
-    cy.get('button[id=saveTableSettings]').click();
+    cy.get(
+      "input[type=checkbox][formcontrolname=transformationEnabled]"
+    ).check();
+    cy.get("button[id=saveTableSettings]").click();
     cy.createOtherReport();
-    cy.get('#RefreshButton').click();
-    cy.wait(100)
-    cy.get('.table-responsive tbody').find('tr').should('have.length', 1).click();
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li').should('have.length', 1);
+    cy.get("#RefreshButton").click();
+
+    cy.wait(100);
+    cy.get(".table-responsive tbody")
+      .find("tr")
+      .should("have.length", 1)
+      .click();
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li").should("have.length", 1);
     // We test that the top node was not selected before.
-    cy.get('#debug-tree .jqx-tree-dropdown-root > li > div').click();
-    cy.get('#editor').contains('Name="IGNORED"');
+    cy.get("#debug-tree .jqx-tree-dropdown-root > li > div").click();
+    cy.get("[data-cy-open-metadata-table]").click();
+    cy.get("#editor").contains('Name="IGNORED"');
     // The transformation should not affect the report table, only the XML in the Monaco editor
-    cy.get('#displayedNodeTable tr:eq(0) td:eq(0)').should('have.text', 'Name');
-    cy.get('#displayedNodeTable tr:eq(0) td:eq(1)').should('have.text', 'Another simple report');
+    cy.get("[data-cy-metadata-table-reportname]").should(
+      "have.text",
+      "Name: Another simple report"
+    );
   });
 });

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="p-3" id="ladybug-tabs">
+<div class="px-2 pt-1 pb-2" id="ladybug-tabs">
   <ul ngbNav #nav="ngbNav" [(activeId)]="active" (navChange)="detectTabChange($event)" class="nav-tabs">
     <li [ngbNavItem]="1" id="debugTab" [destroyOnHide]="false">
       <a ngbNavLink>Debug</a>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,7 +25,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { jqxTreeModule } from 'jqwidgets-ng/jqxtree';
 import { CompareTreeComponent } from './compare/compare-tree/compare-tree.component';
 import { EditDisplayComponent } from './report/edit-display/edit-display.component';
-import { MatProgressSpinner, MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DebugTreeComponent } from './debug/debug-tree/debug-tree.component';
 import { ToggleComponent } from './shared/components/toggle/toggle.component';
 import { EditorComponent } from './shared/components/editor/editor.component';
@@ -33,6 +33,7 @@ import { AngularSplitModule } from 'angular-split';
 import { DeleteModalComponent } from './test/delete-modal/delete-modal.component';
 import { TextCompareComponent } from './text-compare/text-compare.component';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+import { TableCellShortenerPipe } from './shared/pipes/table-cell-shortener.pipe';
 
 @NgModule({
   declarations: [
@@ -72,6 +73,7 @@ import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
     MatProgressSpinnerModule,
     AngularSplitModule,
     MonacoEditorModule.forRoot(),
+    TableCellShortenerPipe,
   ],
   providers: [CookieService],
   bootstrap: [AppComponent],

--- a/src/app/debug/display/display.component.html
+++ b/src/app/debug/display/display.component.html
@@ -1,7 +1,8 @@
 <div [hidden]="!displayReport">
   <div class="row" id="displayButtons">
     <app-button [icon]="'fa fa-copy'" [title]="'Copy'" (click)="copyReport()"></app-button>
-    <app-button *ngIf="report.encoding === 'Base64'" [text]="'Base64'" [title]="'Convert to Base64'" (click)="changeEncoding($event)"></app-button>
+    <app-button *ngIf="report.encoding === 'Base64'" [text]="'Base64'" [title]="'Convert to Base64'"
+                (click)="changeEncoding($event)"></app-button>
 
     <div ngbDropdown title="Download">
       <button class="btn btn-info my-2 mx-1" id="dropdownDownloadDisplay" ngbDropdownToggle>
@@ -9,20 +10,32 @@
       </button>
       <div ngbDropdownMenu aria-labelledby="dropdownDownloadDisplay">
         <button ngbDropdownItem (click)="downloadReport(true, true)">XML & Binary</button>
-        <button ngbDropdownItem (click)="downloadReport(false, true)">XML <i class="fa fa-info-circle" title="Only a binary file can be uploaded again"></i></button>
+        <button ngbDropdownItem (click)="downloadReport(false, true)">XML <i class="fa fa-info-circle"
+                                                                             title="Only a binary file can be uploaded again"></i>
+        </button>
         <button ngbDropdownItem (click)="downloadReport(true, false)">Binary</button>
       </div>
     </div>
 
     <app-button [icon]="'fa fa-times'" [title]="'Close'" (click)="closeReport(true)"></app-button>
+    <button data-cy-open-metadata-table class="btn btn-info my-2 mx-1 px-3" title="Open metadata table" (click)="toggleMetadataTable()">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" color="white"
+           viewBox="0 0 16 16">
+        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+        <path
+          d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+      </svg>
+    </button>
   </div>
 
   <div *ngIf="!report.xml">
     <div *ngIf="report.noCloseReceivedForStream" id="noCloseReceivedLabel" class="btn btn-static my-2 mx-1 px-2">
       No close received for stream
     </div>
-    <div *ngIf="null !== report.streaming && report.streaming" id="waitingForMessageLabel" class="btn btn-static my-2 mx-1 px-2">
-      {{ report.waitingForStream ? 'Waiting for message to be' : 'Message is'}} captured asynchronously from a {{report.streaming.toLowerCase()}} stream
+    <div *ngIf="null !== report.streaming && report.streaming" id="waitingForMessageLabel"
+         class="btn btn-static my-2 mx-1 px-2">
+      {{ report.waitingForStream ? 'Waiting for message to be' : 'Message is'}} captured asynchronously from
+      a {{report.streaming.toLowerCase()}} stream
     </div>
 
     <div *ngIf="null === report.message" id="nullMessageLabel" class="btn btn-static my-2 mx-1 px-2">
@@ -51,9 +64,8 @@
     </div>
   </div>
 
-  <app-editor id="editor"></app-editor>
-
-  <div class="pt-4">
+  <div *ngIf="metadataTableVisible">
     <app-display-table [report]="report"></app-display-table>
   </div>
+  <app-editor class="h-100" id="editor"></app-editor>
 </div>

--- a/src/app/debug/display/display.component.ts
+++ b/src/app/debug/display/display.component.ts
@@ -1,7 +1,11 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-// @ts-ignore
-import DiffMatchPatch from 'diff-match-patch';
 import { HttpService } from '../../shared/services/http.service';
 import { DisplayTableComponent } from '../../shared/components/display-table/display-table.component';
 import { HelperService } from '../../shared/services/helper.service';
@@ -20,12 +24,19 @@ export class DisplayComponent {
   @ViewChild(EditorComponent) editor!: EditorComponent;
   @ViewChild(DisplayTableComponent)
   displayTableComponent!: DisplayTableComponent;
+  metadataTableVisible: boolean = false;
 
-  constructor(private modalService: NgbModal, private httpService: HttpService, private helperService: HelperService) {}
+  constructor(
+    private modalService: NgbModal,
+    private httpService: HttpService,
+    private helperService: HelperService
+  ) {}
 
   showReport(report: any): void {
     this.report = report;
-    report.xml ? this.editor.setValue(report.xml) : this.editor.setValue(this.helperService.convertMessage(report));
+    report.xml
+      ? this.editor.setValue(report.xml)
+      : this.editor.setValue(this.helperService.convertMessage(report));
     this.displayReport = true;
   }
 
@@ -37,19 +48,34 @@ export class DisplayComponent {
   }
 
   changeEncoding(button: any): void {
-    this.editor.setValue(this.helperService.changeEncoding(this.report, button));
+    this.editor.setValue(
+      this.helperService.changeEncoding(this.report, button)
+    );
   }
 
   copyReport(): void {
-    const storageId: number = this.report.xml ? +this.report.storageId : +this.report.uid.split('#')[0];
+    const storageId: number = this.report.xml
+      ? +this.report.storageId
+      : +this.report.uid.split('#')[0];
     const data: any = {};
     data[this.currentView.storageName] = [storageId];
     this.httpService.copyReport(data, 'Test').subscribe(); // TODO: storage is hardcoded, fix issue #196 for this
   }
 
   downloadReport(exportBinary: boolean, exportXML: boolean): void {
-    let queryString: string = this.report.xml ? this.report.storageId.toString() : this.report.uid.split('#')[0];
-    this.helperService.download('id=' + queryString + '&', this.currentView.storageName, exportBinary, exportXML);
+    let queryString: string = this.report.xml
+      ? this.report.storageId.toString()
+      : this.report.uid.split('#')[0];
+    this.helperService.download(
+      'id=' + queryString + '&',
+      this.currentView.storageName,
+      exportBinary,
+      exportXML
+    );
     this.httpService.handleSuccess('Report Downloaded!');
+  }
+
+  toggleMetadataTable() {
+    this.metadataTableVisible = !this.metadataTableVisible;
   }
 }

--- a/src/app/debug/display/display.component.ts
+++ b/src/app/debug/display/display.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { HttpService } from '../../shared/services/http.service';
 import { DisplayTableComponent } from '../../shared/components/display-table/display-table.component';
@@ -26,17 +20,11 @@ export class DisplayComponent {
   displayTableComponent!: DisplayTableComponent;
   metadataTableVisible: boolean = false;
 
-  constructor(
-    private modalService: NgbModal,
-    private httpService: HttpService,
-    private helperService: HelperService
-  ) {}
+  constructor(private modalService: NgbModal, private httpService: HttpService, private helperService: HelperService) {}
 
   showReport(report: any): void {
     this.report = report;
-    report.xml
-      ? this.editor.setValue(report.xml)
-      : this.editor.setValue(this.helperService.convertMessage(report));
+    report.xml ? this.editor.setValue(report.xml) : this.editor.setValue(this.helperService.convertMessage(report));
     this.displayReport = true;
   }
 
@@ -48,30 +36,19 @@ export class DisplayComponent {
   }
 
   changeEncoding(button: any): void {
-    this.editor.setValue(
-      this.helperService.changeEncoding(this.report, button)
-    );
+    this.editor.setValue(this.helperService.changeEncoding(this.report, button));
   }
 
   copyReport(): void {
-    const storageId: number = this.report.xml
-      ? +this.report.storageId
-      : +this.report.uid.split('#')[0];
+    const storageId: number = this.report.xml ? +this.report.storageId : +this.report.uid.split('#')[0];
     const data: any = {};
     data[this.currentView.storageName] = [storageId];
     this.httpService.copyReport(data, 'Test').subscribe(); // TODO: storage is hardcoded, fix issue #196 for this
   }
 
   downloadReport(exportBinary: boolean, exportXML: boolean): void {
-    let queryString: string = this.report.xml
-      ? this.report.storageId.toString()
-      : this.report.uid.split('#')[0];
-    this.helperService.download(
-      'id=' + queryString + '&',
-      this.currentView.storageName,
-      exportBinary,
-      exportXML
-    );
+    let queryString: string = this.report.xml ? this.report.storageId.toString() : this.report.uid.split('#')[0];
+    this.helperService.download('id=' + queryString + '&', this.currentView.storageName, exportBinary, exportXML);
     this.httpService.handleSuccess('Report Downloaded!');
   }
 

--- a/src/app/debug/table/table-settings-modal/table-settings-modal.component.html
+++ b/src/app/debug/table/table-settings-modal/table-settings-modal.component.html
@@ -22,6 +22,16 @@
       </div>
       <hr>
       <div class="form-group">
+        <h5>Report table</h5>
+        <div title="Configure the amount of spacing in the report table">
+          <label for="show-multiple">Spacing for report table</label>
+          <select #spacingOptionsDropdown class="form-control custom-select mr-sm-2" (click)="changeTableSpacing(spacingOptionsDropdown.value)">
+            <option [value]="option" *ngFor="let option of spacingOptions" [selected]="option === tableSpacing">{{option}}</option>
+          </select>
+        </div>
+      </div>
+      <hr>
+      <div class="form-group">
         <label>Report generator</label>
         <select class="form-control custom-select mr-sm-2" formControlName="generatorEnabled">
           <option>Enabled</option>

--- a/src/app/debug/table/table-settings-modal/table-settings-modal.component.html
+++ b/src/app/debug/table/table-settings-modal/table-settings-modal.component.html
@@ -26,7 +26,7 @@
         <div title="Configure the amount of spacing in the report table">
           <label for="show-multiple">Spacing for report table</label>
           <select #spacingOptionsDropdown class="form-control custom-select mr-sm-2" (click)="changeTableSpacing(spacingOptionsDropdown.value)">
-            <option [value]="option" *ngFor="let option of spacingOptions" [selected]="option === tableSpacing">{{option}}</option>
+            <option [value]="option" *ngFor="let option of spacingOptions" [selected]="option === tableSpacing">{{option}}x</option>
           </select>
         </div>
       </div>

--- a/src/app/debug/table/table-settings-modal/table-settings-modal.component.ts
+++ b/src/app/debug/table/table-settings-modal/table-settings-modal.component.ts
@@ -16,7 +16,7 @@ export class TableSettingsModalComponent implements OnDestroy {
   @ViewChild('modal') modal!: ElementRef;
   showMultipleAtATime!: boolean;
   showMultipleAtATimeSubscription!: Subscription;
-  tableSpacing: number = 0;
+  tableSpacing: number = 1;
   spacingOptions: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
   tableSpacingSubscription!: Subscription;
   settingsForm: UntypedFormGroup = new UntypedFormGroup({

--- a/src/app/debug/table/table-settings-modal/table-settings-modal.component.ts
+++ b/src/app/debug/table/table-settings-modal/table-settings-modal.component.ts
@@ -16,8 +16,12 @@ export class TableSettingsModalComponent implements OnDestroy {
   @ViewChild('modal') modal!: ElementRef;
   showMultipleAtATime!: boolean;
   showMultipleAtATimeSubscription!: Subscription;
-  settingsForm = new UntypedFormGroup({
+  tableSpacing: number = 0;
+  spacingOptions: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+  tableSpacingSubscription!: Subscription;
+  settingsForm: UntypedFormGroup = new UntypedFormGroup({
     showMultipleFilesAtATime: new UntypedFormControl(false),
+    tableSpacing: new UntypedFormControl(this.tableSpacing),
     generatorEnabled: new UntypedFormControl('Enabled'),
     regexFilter: new UntypedFormControl(''),
     transformationEnabled: new UntypedFormControl(true),
@@ -38,6 +42,7 @@ export class TableSettingsModalComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.showMultipleAtATimeSubscription.unsubscribe();
+    this.tableSpacingSubscription.unsubscribe();
   }
 
   subscribeToSettingsServiceObservables(): void {
@@ -47,6 +52,10 @@ export class TableSettingsModalComponent implements OnDestroy {
         this.settingsForm.get('showMultipleFilesAtATime')?.setValue(this.showMultipleAtATime);
       }
     );
+    this.tableSpacingSubscription = this.settingsService.tableSpacingObservable.subscribe((value: number) => {
+      this.tableSpacing = value;
+      this.settingsForm.get('tableSpacing')?.setValue(this.tableSpacing);
+    });
   }
 
   setShowMultipleAtATime() {
@@ -120,5 +129,9 @@ export class TableSettingsModalComponent implements OnDestroy {
     this.cookieService.set('generatorEnabled', generatorStatus);
     this.settingsForm.get('generatorEnabled')?.setValue(generatorStatus);
     this.settingsForm.get('regexFilter')?.setValue(response.regexFilter);
+  }
+
+  changeTableSpacing(value: any): void {
+    this.settingsService.setTableSpacing(Number(value));
   }
 }

--- a/src/app/debug/table/table.component.css
+++ b/src/app/debug/table/table.component.css
@@ -25,7 +25,53 @@
   height: 100%;
 }
 
+tr {
+  padding: 0.05rem 0 0.05rem 0;
+}
+
+th {
+  padding: 0 0 0 0;
+}
+
+td {
+  padding: 0;
+}
+
 .table-row:hover {
   cursor: pointer;
   filter: brightness(85%);
+}
+
+.table-row-checkbox {
+  display: table-cell;
+  flex-direction: row;
+  justify-content: center;
+  text-align: center;
+  vertical-align: middle;
+  padding-right: 0.25rem;
+}
+
+.header-padding {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  border-top: 0;
+  border-bottom-width: 1px;
+}
+
+.table-cell {
+  width: fit-content;
+  vertical-align: middle;
+}
+
+.header-cell > div {
+  margin: 0 auto auto 0;
+}
+
+.filter-header {
+  vertical-align: middle;
+  padding-right: 0.25rem;
+}
+
+.vertical-middle {
+  vertical-align: middle;
 }

--- a/src/app/debug/table/table.component.css
+++ b/src/app/debug/table/table.component.css
@@ -25,16 +25,8 @@
   height: 100%;
 }
 
-tr {
-  padding: 0.05rem 0 0.05rem 0;
-}
-
 th {
   padding: 0 0 0 0;
-}
-
-td {
-  padding: 0;
 }
 
 .table-row:hover {
@@ -48,7 +40,6 @@ td {
   justify-content: center;
   text-align: center;
   vertical-align: middle;
-  padding-right: 0.25rem;
 }
 
 .header-padding {

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -20,11 +20,9 @@
     </button>
 
     <app-button [title]="'Open Selected Reports'" [text]="'Open Selected'" (click)="openSelected()"></app-button>
-    <app-button [title]="'Select All Reports'" [text]="'Select All'" (click)="selectAll()"></app-button>
-    <app-button [title]="'Deselect All Reports'" [text]="'Deselect All'" (click)="deselectAll()"></app-button>
     <app-button [title]="'Delete'" [icon]="'fa fa-trash'" (click)="deleteSelected()"></app-button>
 
-    <form class="form-horizontal pt-2" (keydown.enter)="$event.preventDefault();" (keyup.enter)="changeTableLimit($event)">
+    <form class="pt-2" (keydown.enter)="$event.preventDefault();" (keyup.enter)="changeTableLimit($event)">
       <div class="input-group-append">
           <input type="number" id="displayAmount" class="form-control px-1" value="{{tableSettings.displayAmount}}" (blur)="changeTableLimit($event)">
         <div class="input-group-text">/{{metadataCount}}</div>
@@ -38,9 +36,8 @@
     </div>
 
     <div class="btn btn-static my-2 mx-1 px-2"> Reports in progress: {{ tableSettings.reportsInProgress }}</div>
-    <span class="row" *ngIf="tableSettings.reportsInProgress > 0">
+    <div class="row" *ngIf="tableSettings.reportsInProgress > 0">
       <div class="btn btn-static my-2 mx-1 px-2"> Estimated memory usage of reports in progress: {{ tableSettings.estimatedMemoryUsage }} Bytes</div>
-
         <div class="col input-group my-2 mx-1 px-2">
           <input #openIndex type="number"  min="0" value="{{tableSettings.reportsInProgress}}" max="{{tableSettings.reportsInProgress}}" (change)="disableReportInProgressButton(+openIndex.value, '#openReportInProgressButton')" class="form-control" id="openInProgressNo"/>
           <div class="input-group-append">
@@ -55,7 +52,7 @@
             </div>
           </div>
 
-    </span>
+    </div>
 
     <app-button [text]="'Compare'" [title]="'Compare'" *ngIf="showCompareButton()" (click)="compareTwoReports()"></app-button>
     <app-button [text]="'Open In New Tab'" *ngIf="showOpenInTabButton()" (click)="openReportInTab()"></app-button>
@@ -68,14 +65,17 @@
     <table class="table mb-0" matSort (matSortChange)="helperService.sortData($event, tableSettings.reportMetadata)">
       <thead id="table-header">
         <tr>
-          <th>Select</th>
-          <th *ngFor="let header of viewSettings.currentView.metadataLabels; let i = index" mat-sort-header="{{i}}">{{header}}</th>
+          <th class="table-row-checkbox header-padding">
+            <input type="checkbox" class="vertical-middle" data-cy-select-all-reports [checked]="allRowsSelected" (click)="selectAllRows()" title="Select all rows">
+          </th>
+          <th class="text-center header-cell header-padding" *ngFor="let header of viewSettings.currentView.metadataLabels; let i = index"
+              mat-sort-header="{{i}}" [title]="header">{{getShortenedTableHeaderNames(header)}}</th>
         </tr>
         <tr id="filterRow" *ngIf="tableSettings.showFilter">
-          <th>
+          <th class="vertical-middle">
             <app-button [icon]="'fa fa-undo'" [title]="'Clear filters'" (click)="clearFilters()"></app-button>
           </th>
-          <th *ngFor="let header of viewSettings.currentView.metadataNames">
+          <th *ngFor="let header of viewSettings.currentView.metadataNames" class="filter-header">
             <div class="input-group">
               <input type="text" id="filter"  title="{{tableSettings.metadataHeaders[header]}}" class="form-control" placeholder="Filter for {{header}}" (keydown.enter)="changeFilter($event, header)">
             </div>
@@ -88,10 +88,10 @@
             [ngClass]="{'highlight': selectedRow === i}"
             style="background-color: {{getStatusColor(row)}}"
         >
-          <td>
+          <td class="table-row-checkbox">
             <input type="checkbox" [checked]="row.checked" (click)="toggleCheck(row)">
           </td>
-          <td *ngFor="let metadataName of viewSettings.currentView.metadataNames" (click)="openReport(row.storageId);">{{row[metadataName]}}</td>
+          <td class="table-cell" *ngFor="let metadataName of viewSettings.currentView.metadataNames" (click)="openReport(row.storageId);" [title]="row[metadataName]">{{row[metadataName]|tableCellShortener}}</td>
         </tr>
       </tbody>
     </table>

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -62,11 +62,11 @@
     <mat-spinner [mode]="'indeterminate'" [diameter]="30"></mat-spinner>
   </div>
   <div [hidden]="!doneRetrieving" class="table-responsive" id="metadataTable">
-    <table class="table mb-0" matSort (matSortChange)="helperService.sortData($event, tableSettings.reportMetadata)">
+    <table class="table mb-0" matSort (matSortChange)="helperService.sortData($event, tableSettings.reportMetadata)" [style.font-size]="getFontSize()">
       <thead id="table-header">
         <tr>
           <th class="table-row-checkbox header-padding">
-            <input type="checkbox" class="vertical-middle" data-cy-select-all-reports [checked]="allRowsSelected" (click)="selectAllRows()" title="Select all rows">
+            <input type="checkbox" class="vertical-middle" data-cy-select-all-reports [checked]="allRowsSelected" (click)="selectAllRows()" title="Select all rows" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()">
           </th>
           <th class="text-center header-cell header-padding" *ngFor="let header of viewSettings.currentView.metadataLabels; let i = index"
               mat-sort-header="{{i}}" [title]="header">{{getShortenedTableHeaderNames(header)}}</th>
@@ -86,13 +86,13 @@
         <tr class="table-row" *ngFor="let row of tableSettings.reportMetadata.slice(0, tableSettings.displayAmount); let i = index"
             (click)="highLightRow(i);"
             [ngClass]="{'highlight': selectedRow === i}"
-            style="background-color: {{getStatusColor(row)}}"
+            style="background-color: {{getStatusColor(row)}};"
             [attr.data-cy-record-table-index]=i
         >
-          <td class="table-row-checkbox">
-            <input type="checkbox" [checked]="row.checked" (click)="toggleCheck(row)">
+          <td class="table-row-checkbox" [style.padding]="getTableSpacing()">
+            <input type="checkbox" [checked]="row.checked" (click)="toggleCheck(row)" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()">
           </td>
-          <td class="table-cell" *ngFor="let metadataName of viewSettings.currentView.metadataNames" (click)="openReport(row.storageId);" [title]="row[metadataName]">{{row[metadataName]|tableCellShortener}}</td>
+          <td [style.padding]="getTableSpacing()" class="table-cell" *ngFor="let metadataName of viewSettings.currentView.metadataNames" (click)="openReport(row.storageId);" [title]="row[metadataName]">{{row[metadataName]|tableCellShortener}}</td>
         </tr>
       </tbody>
     </table>

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -1,4 +1,10 @@
-import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { ToastComponent } from '../../shared/components/toast/toast.component';
 import { HelperService } from '../../shared/services/helper.service';
 import { HttpService } from '../../shared/services/http.service';
@@ -23,6 +29,27 @@ export class TableComponent implements OnInit {
     currentView: {},
     currentViewName: '',
   };
+
+  allRowsSelected: boolean = false;
+
+  shortenedTableHeaders: Map<string, string> = new Map([
+    ['Storage Id', 'Storage Id'],
+    ['End time', 'End time'],
+    ['Duration', 'Duration'],
+    ['Name', 'Name'],
+    ['Correlation Id', 'Correlation Id'],
+    ['Status', 'Status'],
+    ['Number of checkpoints', 'Checkpoints'],
+    ['Estimated memory usage', 'Memory'],
+    ['Storage size', 'Size'],
+    ['TIMESTAMP', 'TIMESTAMP'],
+    ['COMPONENT', 'COMPONENT'],
+    ['ENDPOINT NAME', 'ENDPOINT'],
+    ['CONVERSATION ID', 'CONVERSATION ID'],
+    ['CORRELATION ID', 'CORRELATION ID'],
+    ['NR OF CHECKPOINTS', 'NR OF CHECKPOINTS'],
+    ['STATUS', 'STATUS'],
+  ]);
 
   tableSettings: TableSettings = {
     reportMetadata: [],
@@ -92,7 +119,10 @@ export class TableComponent implements OnInit {
 
   getUserHelp() {
     this.httpService
-      .getUserHelp(this.viewSettings.currentView.storageName, this.viewSettings.currentView.metadataNames)
+      .getUserHelp(
+        this.viewSettings.currentView.storageName,
+        this.viewSettings.currentView.metadataNames
+      )
       .subscribe({
         next: (response) => {
           this.tableSettings.metadataHeaders = response;
@@ -101,7 +131,8 @@ export class TableComponent implements OnInit {
   }
 
   clearFilters() {
-    let element: NodeListOf<HTMLInputElement> = document.querySelectorAll('#filter')!;
+    let element: NodeListOf<HTMLInputElement> =
+      document.querySelectorAll('#filter')!;
     element.forEach((element: HTMLInputElement) => {
       element.value = '';
     });
@@ -112,6 +143,7 @@ export class TableComponent implements OnInit {
   }
 
   changeView(event: any) {
+    this.allRowsSelected = false;
     this.viewSettings.currentView = this.viewSettings.views[event.target.value];
     this.viewSettings.currentView.name = event.target.value;
     this.clearFilters();
@@ -127,7 +159,8 @@ export class TableComponent implements OnInit {
           (view) => view === this.viewSettings.currentView.name
         );
         if (viewToUpdate) {
-          this.viewSettings.currentView.nodeLinkStrategy = views[viewToUpdate].nodeLinkStrategy;
+          this.viewSettings.currentView.nodeLinkStrategy =
+            views[viewToUpdate].nodeLinkStrategy;
         }
       });
     });
@@ -139,11 +172,12 @@ export class TableComponent implements OnInit {
         this.changeViewEvent.emit(this.viewSettings.currentView);
       } else {
         this.viewSettings.views = views;
-        this.viewSettings.currentViewName = Object.keys(this.viewSettings.views).find(
-          (view) => this.viewSettings.views[view].defaultView
-        );
+        this.viewSettings.currentViewName = Object.keys(
+          this.viewSettings.views
+        ).find((view) => this.viewSettings.views[view].defaultView);
 
-        this.viewSettings.currentView = this.viewSettings.views[this.viewSettings.currentViewName];
+        this.viewSettings.currentView =
+          this.viewSettings.views[this.viewSettings.currentViewName];
         this.viewSettings.currentView.name = this.viewSettings.currentViewName;
         this.changeViewEvent.emit(this.viewSettings.currentView);
       }
@@ -156,9 +190,11 @@ export class TableComponent implements OnInit {
   }
 
   loadMetadataCount() {
-    this.httpService.getMetadataCount(this.viewSettings.currentView.storageName).subscribe((count: any) => {
-      this.metadataCount = count;
-    });
+    this.httpService
+      .getMetadataCount(this.viewSettings.currentView.storageName)
+      .subscribe((count: any) => {
+        this.metadataCount = count;
+      });
   }
 
   loadReportInProgressSettings() {
@@ -182,34 +218,57 @@ export class TableComponent implements OnInit {
     report.checked = !report.checked;
   }
 
+  selectAllRows(): void {
+    this.allRowsSelected = !this.allRowsSelected;
+    if (this.allRowsSelected) {
+      this.selectAll();
+    } else {
+      this.deselectAll();
+    }
+  }
+
   getStatusColor(metadata: any): string {
-    let statusName = this.viewSettings.currentView.metadataNames.find((name: string) => {
-      return name.toLowerCase() === 'status';
-    });
+    let statusName = this.viewSettings.currentView.metadataNames.find(
+      (name: string) => {
+        return name.toLowerCase() === 'status';
+      }
+    );
     if (statusName && metadata[statusName]) {
-      return metadata[statusName].toLowerCase() === 'success' ? '#c3e6cb' : '#f79c9c';
+      return metadata[statusName].toLowerCase() === 'success'
+        ? '#c3e6cb'
+        : '#f79c9c';
     }
     return 'none';
   }
 
   showCompareButton(): boolean {
-    return this.tableSettings.reportMetadata.filter((report) => report.checked).length == 2;
+    return (
+      this.tableSettings.reportMetadata.filter((report) => report.checked)
+        .length == 2
+    );
   }
 
   showOpenInTabButton(): boolean {
-    return this.tableSettings.reportMetadata.filter((report) => report.checked).length == 1;
+    return (
+      this.tableSettings.reportMetadata.filter((report) => report.checked)
+        .length == 1
+    );
   }
 
   openReportInTab(): void {
-    let reportTab = this.tableSettings.reportMetadata.find((report) => report.checked);
-    this.httpService.getReport(reportTab.storageId, this.viewSettings.currentView.storageName).subscribe((data) => {
-      let report: Report = data.report;
-      report.xml = data.xml;
-      this.openReportInSeparateTabEvent.emit({
-        data: report,
-        name: report.name,
+    let reportTab = this.tableSettings.reportMetadata.find(
+      (report) => report.checked
+    );
+    this.httpService
+      .getReport(reportTab.storageId, this.viewSettings.currentView.storageName)
+      .subscribe((data) => {
+        let report: Report = data.report;
+        report.xml = data.xml;
+        this.openReportInSeparateTabEvent.emit({
+          data: report,
+          name: report.name,
+        });
       });
-    });
   }
 
   openSelected(): void {
@@ -221,18 +280,26 @@ export class TableComponent implements OnInit {
   }
 
   deleteSelected(): void {
-    const reportIds = this.helperService.getSelectedIds(this.tableSettings.reportMetadata);
-    this.httpService.deleteReport(reportIds, this.viewSettings.currentView.storageName).subscribe(() => {
-      this.retrieveRecords();
-    });
+    const reportIds = this.helperService.getSelectedIds(
+      this.tableSettings.reportMetadata
+    );
+    this.httpService
+      .deleteReport(reportIds, this.viewSettings.currentView.storageName)
+      .subscribe(() => {
+        this.retrieveRecords();
+      });
   }
 
   selectAll(): void {
-    this.tableSettings.reportMetadata.forEach((report) => (report.checked = true));
+    this.tableSettings.reportMetadata.forEach(
+      (report) => (report.checked = true)
+    );
   }
 
   deselectAll(): void {
-    this.tableSettings.reportMetadata.forEach((report) => (report.checked = false));
+    this.tableSettings.reportMetadata.forEach(
+      (report) => (report.checked = false)
+    );
   }
 
   compareTwoReports() {
@@ -241,28 +308,30 @@ export class TableComponent implements OnInit {
     let selectedReports: string[] = this.tableSettings.reportMetadata
       .filter((report) => report.checked)
       .map((report) => report.storageId);
-    this.httpService.getReports(selectedReports, this.viewSettings.currentView.storageName).subscribe({
-      next: (data) => {
-        let leftObject = data[selectedReports[0]];
-        let originalReport = leftObject.report;
-        originalReport.xml = leftObject.xml;
+    this.httpService
+      .getReports(selectedReports, this.viewSettings.currentView.storageName)
+      .subscribe({
+        next: (data) => {
+          let leftObject = data[selectedReports[0]];
+          let originalReport = leftObject.report;
+          originalReport.xml = leftObject.xml;
 
-        let rightObject = data[selectedReports[1]];
-        let runResultReport = rightObject.report;
-        runResultReport.xml = rightObject.xml;
+          let rightObject = data[selectedReports[1]];
+          let runResultReport = rightObject.report;
+          runResultReport.xml = rightObject.xml;
 
-        compareReports = {
-          originalReport: originalReport,
-          runResultReport: runResultReport,
-          viewName: this.viewSettings.currentView.name,
-          nodeLinkStrategy: this.viewSettings.currentView.nodeLinkStrategy,
-        };
-      },
+          compareReports = {
+            originalReport: originalReport,
+            runResultReport: runResultReport,
+            viewName: this.viewSettings.currentView.name,
+            nodeLinkStrategy: this.viewSettings.currentView.nodeLinkStrategy,
+          };
+        },
 
-      complete: () => {
-        this.openSelectedCompareReportsEvent.emit(compareReports);
-      },
-    });
+        complete: () => {
+          this.openSelectedCompareReportsEvent.emit(compareReports);
+        },
+      });
   }
 
   changeFilter(event: any, header: string): void {
@@ -273,7 +342,8 @@ export class TableComponent implements OnInit {
   }
 
   changeTableLimit(event: any): void {
-    this.tableSettings.displayAmount = event.target.value === '' ? 0 : event.target.value;
+    this.tableSettings.displayAmount =
+      event.target.value === '' ? 0 : event.target.value;
     this.retrieveRecords();
   }
 
@@ -286,12 +356,14 @@ export class TableComponent implements OnInit {
   }
 
   openReport(storageId: string): void {
-    this.httpService.getReport(storageId, this.viewSettings.currentView.storageName).subscribe((data) => {
-      let report: Report = data.report;
-      report.xml = data.xml;
-      report.storageName = this.viewSettings.currentView.storageName;
-      this.openReportEvent.next(report);
-    });
+    this.httpService
+      .getReport(storageId, this.viewSettings.currentView.storageName)
+      .subscribe((data) => {
+        let report: Report = data.report;
+        report.xml = data.xml;
+        report.storageName = this.viewSettings.currentView.storageName;
+        this.openReportEvent.next(report);
+      });
   }
 
   highLightRow(event: any) {
@@ -299,11 +371,13 @@ export class TableComponent implements OnInit {
   }
 
   openLatestReports(amount: number): void {
-    this.httpService.getLatestReports(amount, this.viewSettings.currentView.storageName).subscribe((data) => {
-      data.forEach((report: any) => {
-        this.openReportEvent.next(report);
+    this.httpService
+      .getLatestReports(amount, this.viewSettings.currentView.storageName)
+      .subscribe((data) => {
+        data.forEach((report: any) => {
+          this.openReportEvent.next(report);
+        });
       });
-    });
   }
 
   openReportInProgress(index: number) {
@@ -322,20 +396,30 @@ export class TableComponent implements OnInit {
 
   disableReportInProgressButton(index: number, selector: string) {
     let element: HTMLButtonElement = document.querySelector(selector)!;
-    element.disabled = index == 0 || index > this.tableSettings.reportsInProgress;
+    element.disabled =
+      index == 0 || index > this.tableSettings.reportsInProgress;
   }
 
   downloadReports(exportBinary: boolean, exportXML: boolean): void {
     const queryString: string = this.tableSettings.reportMetadata
       .filter((report) => report.checked)
-      .reduce((totalQuery: string, selectedReport: any) => totalQuery + 'id=' + selectedReport.storageId + '&', '');
+      .reduce(
+        (totalQuery: string, selectedReport: any) =>
+          totalQuery + 'id=' + selectedReport.storageId + '&',
+        ''
+      );
     if (queryString === '') {
       this.toastComponent.addAlert({
         type: 'warning',
         message: 'No reports selected to download',
       });
     } else {
-      this.helperService.download(queryString, this.viewSettings.currentView.storageName, exportBinary, exportXML);
+      this.helperService.download(
+        queryString,
+        this.viewSettings.currentView.storageName,
+        exportBinary,
+        exportXML
+      );
     }
   }
 
@@ -354,5 +438,13 @@ export class TableComponent implements OnInit {
         this.openReportEvent.next(report);
       }
     });
+  }
+
+  //TODO: fix on backend
+  getShortenedTableHeaderNames(fullName: string): string {
+    if (this.shortenedTableHeaders.has(fullName)) {
+      return this.shortenedTableHeaders.get(fullName) as string;
+    }
+    return fullName;
   }
 }

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -201,7 +201,21 @@ export class TableComponent implements OnInit {
   }
 
   toggleCheck(report: any): void {
+    console.log(report);
     report.checked = !report.checked;
+    if (this.allRowsSelected && !report.checked) {
+      this.allRowsSelected = false;
+    }
+    this.allRowsSelected = this.checkIfAllRowsSelected();
+  }
+
+  checkIfAllRowsSelected() {
+    for (let reportMetada of this.tableSettings.reportMetadata) {
+      if (!reportMetada.checked) {
+        return false;
+      }
+    }
+    return true;
   }
 
   selectAllRows(): void {
@@ -306,6 +320,7 @@ export class TableComponent implements OnInit {
   changeTableLimit(event: any): void {
     this.tableSettings.displayAmount = event.target.value === '' ? 0 : event.target.value;
     this.retrieveRecords();
+    this.allRowsSelected = false;
   }
 
   refresh(): void {

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { ToastComponent } from '../../shared/components/toast/toast.component';
 import { HelperService } from '../../shared/services/helper.service';
 import { HttpService } from '../../shared/services/http.service';
@@ -119,10 +113,7 @@ export class TableComponent implements OnInit {
 
   getUserHelp() {
     this.httpService
-      .getUserHelp(
-        this.viewSettings.currentView.storageName,
-        this.viewSettings.currentView.metadataNames
-      )
+      .getUserHelp(this.viewSettings.currentView.storageName, this.viewSettings.currentView.metadataNames)
       .subscribe({
         next: (response) => {
           this.tableSettings.metadataHeaders = response;
@@ -131,8 +122,7 @@ export class TableComponent implements OnInit {
   }
 
   clearFilters() {
-    let element: NodeListOf<HTMLInputElement> =
-      document.querySelectorAll('#filter')!;
+    let element: NodeListOf<HTMLInputElement> = document.querySelectorAll('#filter')!;
     element.forEach((element: HTMLInputElement) => {
       element.value = '';
     });
@@ -159,8 +149,7 @@ export class TableComponent implements OnInit {
           (view) => view === this.viewSettings.currentView.name
         );
         if (viewToUpdate) {
-          this.viewSettings.currentView.nodeLinkStrategy =
-            views[viewToUpdate].nodeLinkStrategy;
+          this.viewSettings.currentView.nodeLinkStrategy = views[viewToUpdate].nodeLinkStrategy;
         }
       });
     });
@@ -172,12 +161,11 @@ export class TableComponent implements OnInit {
         this.changeViewEvent.emit(this.viewSettings.currentView);
       } else {
         this.viewSettings.views = views;
-        this.viewSettings.currentViewName = Object.keys(
-          this.viewSettings.views
-        ).find((view) => this.viewSettings.views[view].defaultView);
+        this.viewSettings.currentViewName = Object.keys(this.viewSettings.views).find(
+          (view) => this.viewSettings.views[view].defaultView
+        );
 
-        this.viewSettings.currentView =
-          this.viewSettings.views[this.viewSettings.currentViewName];
+        this.viewSettings.currentView = this.viewSettings.views[this.viewSettings.currentViewName];
         this.viewSettings.currentView.name = this.viewSettings.currentViewName;
         this.changeViewEvent.emit(this.viewSettings.currentView);
       }
@@ -190,11 +178,9 @@ export class TableComponent implements OnInit {
   }
 
   loadMetadataCount() {
-    this.httpService
-      .getMetadataCount(this.viewSettings.currentView.storageName)
-      .subscribe((count: any) => {
-        this.metadataCount = count;
-      });
+    this.httpService.getMetadataCount(this.viewSettings.currentView.storageName).subscribe((count: any) => {
+      this.metadataCount = count;
+    });
   }
 
   loadReportInProgressSettings() {
@@ -228,47 +214,33 @@ export class TableComponent implements OnInit {
   }
 
   getStatusColor(metadata: any): string {
-    let statusName = this.viewSettings.currentView.metadataNames.find(
-      (name: string) => {
-        return name.toLowerCase() === 'status';
-      }
-    );
+    let statusName = this.viewSettings.currentView.metadataNames.find((name: string) => {
+      return name.toLowerCase() === 'status';
+    });
     if (statusName && metadata[statusName]) {
-      return metadata[statusName].toLowerCase() === 'success'
-        ? '#c3e6cb'
-        : '#f79c9c';
+      return metadata[statusName].toLowerCase() === 'success' ? '#c3e6cb' : '#f79c9c';
     }
     return 'none';
   }
 
   showCompareButton(): boolean {
-    return (
-      this.tableSettings.reportMetadata.filter((report) => report.checked)
-        .length == 2
-    );
+    return this.tableSettings.reportMetadata.filter((report) => report.checked).length == 2;
   }
 
   showOpenInTabButton(): boolean {
-    return (
-      this.tableSettings.reportMetadata.filter((report) => report.checked)
-        .length == 1
-    );
+    return this.tableSettings.reportMetadata.filter((report) => report.checked).length == 1;
   }
 
   openReportInTab(): void {
-    let reportTab = this.tableSettings.reportMetadata.find(
-      (report) => report.checked
-    );
-    this.httpService
-      .getReport(reportTab.storageId, this.viewSettings.currentView.storageName)
-      .subscribe((data) => {
-        let report: Report = data.report;
-        report.xml = data.xml;
-        this.openReportInSeparateTabEvent.emit({
-          data: report,
-          name: report.name,
-        });
+    let reportTab = this.tableSettings.reportMetadata.find((report) => report.checked);
+    this.httpService.getReport(reportTab.storageId, this.viewSettings.currentView.storageName).subscribe((data) => {
+      let report: Report = data.report;
+      report.xml = data.xml;
+      this.openReportInSeparateTabEvent.emit({
+        data: report,
+        name: report.name,
       });
+    });
   }
 
   openSelected(): void {
@@ -280,26 +252,18 @@ export class TableComponent implements OnInit {
   }
 
   deleteSelected(): void {
-    const reportIds = this.helperService.getSelectedIds(
-      this.tableSettings.reportMetadata
-    );
-    this.httpService
-      .deleteReport(reportIds, this.viewSettings.currentView.storageName)
-      .subscribe(() => {
-        this.retrieveRecords();
-      });
+    const reportIds = this.helperService.getSelectedIds(this.tableSettings.reportMetadata);
+    this.httpService.deleteReport(reportIds, this.viewSettings.currentView.storageName).subscribe(() => {
+      this.retrieveRecords();
+    });
   }
 
   selectAll(): void {
-    this.tableSettings.reportMetadata.forEach(
-      (report) => (report.checked = true)
-    );
+    this.tableSettings.reportMetadata.forEach((report) => (report.checked = true));
   }
 
   deselectAll(): void {
-    this.tableSettings.reportMetadata.forEach(
-      (report) => (report.checked = false)
-    );
+    this.tableSettings.reportMetadata.forEach((report) => (report.checked = false));
   }
 
   compareTwoReports() {
@@ -308,30 +272,28 @@ export class TableComponent implements OnInit {
     let selectedReports: string[] = this.tableSettings.reportMetadata
       .filter((report) => report.checked)
       .map((report) => report.storageId);
-    this.httpService
-      .getReports(selectedReports, this.viewSettings.currentView.storageName)
-      .subscribe({
-        next: (data) => {
-          let leftObject = data[selectedReports[0]];
-          let originalReport = leftObject.report;
-          originalReport.xml = leftObject.xml;
+    this.httpService.getReports(selectedReports, this.viewSettings.currentView.storageName).subscribe({
+      next: (data) => {
+        let leftObject = data[selectedReports[0]];
+        let originalReport = leftObject.report;
+        originalReport.xml = leftObject.xml;
 
-          let rightObject = data[selectedReports[1]];
-          let runResultReport = rightObject.report;
-          runResultReport.xml = rightObject.xml;
+        let rightObject = data[selectedReports[1]];
+        let runResultReport = rightObject.report;
+        runResultReport.xml = rightObject.xml;
 
-          compareReports = {
-            originalReport: originalReport,
-            runResultReport: runResultReport,
-            viewName: this.viewSettings.currentView.name,
-            nodeLinkStrategy: this.viewSettings.currentView.nodeLinkStrategy,
-          };
-        },
+        compareReports = {
+          originalReport: originalReport,
+          runResultReport: runResultReport,
+          viewName: this.viewSettings.currentView.name,
+          nodeLinkStrategy: this.viewSettings.currentView.nodeLinkStrategy,
+        };
+      },
 
-        complete: () => {
-          this.openSelectedCompareReportsEvent.emit(compareReports);
-        },
-      });
+      complete: () => {
+        this.openSelectedCompareReportsEvent.emit(compareReports);
+      },
+    });
   }
 
   changeFilter(event: any, header: string): void {
@@ -342,8 +304,7 @@ export class TableComponent implements OnInit {
   }
 
   changeTableLimit(event: any): void {
-    this.tableSettings.displayAmount =
-      event.target.value === '' ? 0 : event.target.value;
+    this.tableSettings.displayAmount = event.target.value === '' ? 0 : event.target.value;
     this.retrieveRecords();
   }
 
@@ -356,14 +317,12 @@ export class TableComponent implements OnInit {
   }
 
   openReport(storageId: string): void {
-    this.httpService
-      .getReport(storageId, this.viewSettings.currentView.storageName)
-      .subscribe((data) => {
-        let report: Report = data.report;
-        report.xml = data.xml;
-        report.storageName = this.viewSettings.currentView.storageName;
-        this.openReportEvent.next(report);
-      });
+    this.httpService.getReport(storageId, this.viewSettings.currentView.storageName).subscribe((data) => {
+      let report: Report = data.report;
+      report.xml = data.xml;
+      report.storageName = this.viewSettings.currentView.storageName;
+      this.openReportEvent.next(report);
+    });
   }
 
   highLightRow(event: any) {
@@ -371,13 +330,11 @@ export class TableComponent implements OnInit {
   }
 
   openLatestReports(amount: number): void {
-    this.httpService
-      .getLatestReports(amount, this.viewSettings.currentView.storageName)
-      .subscribe((data) => {
-        data.forEach((report: any) => {
-          this.openReportEvent.next(report);
-        });
+    this.httpService.getLatestReports(amount, this.viewSettings.currentView.storageName).subscribe((data) => {
+      data.forEach((report: any) => {
+        this.openReportEvent.next(report);
       });
+    });
   }
 
   openReportInProgress(index: number) {
@@ -396,30 +353,20 @@ export class TableComponent implements OnInit {
 
   disableReportInProgressButton(index: number, selector: string) {
     let element: HTMLButtonElement = document.querySelector(selector)!;
-    element.disabled =
-      index == 0 || index > this.tableSettings.reportsInProgress;
+    element.disabled = index == 0 || index > this.tableSettings.reportsInProgress;
   }
 
   downloadReports(exportBinary: boolean, exportXML: boolean): void {
     const queryString: string = this.tableSettings.reportMetadata
       .filter((report) => report.checked)
-      .reduce(
-        (totalQuery: string, selectedReport: any) =>
-          totalQuery + 'id=' + selectedReport.storageId + '&',
-        ''
-      );
+      .reduce((totalQuery: string, selectedReport: any) => totalQuery + 'id=' + selectedReport.storageId + '&', '');
     if (queryString === '') {
       this.toastComponent.addAlert({
         type: 'warning',
         message: 'No reports selected to download',
       });
     } else {
-      this.helperService.download(
-        queryString,
-        this.viewSettings.currentView.storageName,
-        exportBinary,
-        exportXML
-      );
+      this.helperService.download(queryString, this.viewSettings.currentView.storageName, exportBinary, exportXML);
     }
   }
 

--- a/src/app/shared/components/display-table/display-table.component.css
+++ b/src/app/shared/components/display-table/display-table.component.css
@@ -1,7 +1,7 @@
-#displayedNodeTable {
+table {
   width: auto ;
 }
 
-#displayedNodeTable > tr > td {
+table > tr > td {
   padding: 0.3rem !important;
 }

--- a/src/app/shared/components/display-table/display-table.component.html
+++ b/src/app/shared/components/display-table/display-table.component.html
@@ -1,66 +1,69 @@
-<table class="table border" id="displayedNodeTable">
-  <tr>
-    <td>Name</td>
-    <td>{{_report.name}}</td>
-  </tr>
-  <tr  *ngIf="!_report.xml">
-    <td>Type</td>
-    <td>{{getCheckpointType(_report.type)}}</td>
-  </tr>
-  <tr *ngIf="_report.xml">
-    <td>Description</td>
-    <td>{{_report.description}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>Thread name</td>
-    <td>{{ _report.threadName}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>Source class name</td>
-    <td>{{ _report.sourceClassName}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>Message class name</td>
-    <td>{{ _report.messageClassName}}</td>
-  </tr>
-  <tr>
-    <td>Path</td>
-    <td>{{ _report.path}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>CheckpointUID</td>
-    <td>{{ _report.uid}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>Level</td>
-    <td>{{ _report.level}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml">
-    <td>Encoding</td>
-    <td>{{ _report.encoding}}</td>
-  </tr>
-  <tr *ngIf="!_report.xml && _report.message">
-    <td>Number of characters</td>
-    <td>{{ _report.message.length}}</td>
-  </tr>
-  <tr *ngIf="_report.xml">
-    <td>Transformation</td>
-    <td>{{ _report.transformation}}</td>
-  </tr>
-  <tr *ngIf="_report.xml">
-    <td>StorageId</td>
-    <td>{{ _report.storageId}}</td>
-  </tr>
-  <tr *ngIf="_report.xml">
-    <td>Storage</td>
-    <td>{{ _report.storage}}</td>
-  </tr>
-  <tr>
-    <td>Estimated memory usage</td>
-    <td>{{ _report.estimatedMemoryUsage}}</td>
-  </tr>
-  <tr *ngIf="_report.xml">
-    <td>CorrelationId</td>
-    <td>{{ _report.correlationId}}</td>
-  </tr>
-</table>
+<div class="d-flex flex-column">
+  <div class="px-1 py-2" data-cy-metadata-table-reportname><strong>Name:</strong> {{_report.name}}</div>
+  <div class="d-flex flex-row">
+    <table class="table" id="displayedNodeTable">
+      <tr *ngIf="!_report.xml">
+        <td><strong>Type</strong></td>
+        <td>{{getCheckpointType(_report.type)}}</td>
+      </tr>
+      <tr *ngIf="_report.xml">
+        <td><strong>Description</strong></td>
+        <td>{{_report.description}}</td>
+      </tr>
+      <tr *ngIf="!_report.xml">
+        <td><strong>Thread name</strong></td>
+        <td>{{ _report.threadName}}</td>
+      </tr>
+      <tr *ngIf="!_report.xml">
+        <td><strong>Source class name</strong></td>
+        <td>{{ _report.sourceClassName}}</td>
+    </tr>
+      <tr *ngIf="!_report.xml">
+        <td><strong>Message class name</strong></td>
+        <td>{{ _report.messageClassName}}</td>
+      </tr>
+      <tr>
+        <td><strong>Path</strong></td>
+        <td>{{ _report.path}}</td>
+      </tr>
+    </table>
+    <table class="table">
+      <tr *ngIf="!_report.xml">
+        <td><strong>CheckpointUID</strong></td>
+        <td>{{ _report.uid}}</td>
+      </tr>
+      <tr *ngIf="!_report.xml">
+        <td><strong>Level</strong></td>
+        <td>{{ _report.level}}</td>
+      </tr>
+      <tr *ngIf="!_report.xml">
+        <td><strong>Encoding</strong></td>
+        <td>{{ _report.encoding}}</td>
+      </tr>
+      <tr *ngIf="!_report.xml && _report.message">
+        <td><strong>Number of characters</strong></td>
+        <td>{{ _report.message.length}}</td>
+      </tr>
+      <tr *ngIf="_report.xml">
+        <td><strong>Transformation</strong></td>
+        <td>{{ _report.transformation}}</td>
+      </tr>
+      <tr *ngIf="_report.xml">
+        <td><strong>StorageId</strong></td>
+        <td>{{ _report.storageId}}</td>
+      </tr>
+      <tr *ngIf="_report.xml">
+        <td><strong>Storage</strong></td>
+        <td>{{ _report.storage}}</td>
+      </tr>
+      <tr>
+        <td><strong>Estimated memory usage</strong></td>
+        <td>{{ _report.estimatedMemoryUsage}}</td>
+      </tr>
+      <tr *ngIf="_report.xml">
+        <td><strong>CorrelationId</strong></td>
+        <td>{{ _report.correlationId}}</td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/src/app/shared/pipes/table-cell-shortener.pipe.spec.ts
+++ b/src/app/shared/pipes/table-cell-shortener.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TableCellShortenerPipe } from './table-cell-shortener.pipe';
+
+describe('TableCellShortenerPipe', () => {
+  it('create an instance', () => {
+    const pipe = new TableCellShortenerPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/pipes/table-cell-shortener.pipe.ts
+++ b/src/app/shared/pipes/table-cell-shortener.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'tableCellShortener',
+  standalone: true,
+})
+export class TableCellShortenerPipe implements PipeTransform {
+  transform(value: string): string {
+    if (value == undefined) {
+      return value;
+    }
+    if (
+      value.match('\\b\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b')
+    ) {
+      return value.substring(0, value.indexOf('.'));
+    }
+    if (value.length > 32) {
+      return value.substring(0, 32) + '...';
+    }
+    return value;
+  }
+}

--- a/src/app/shared/pipes/table-cell-shortener.pipe.ts
+++ b/src/app/shared/pipes/table-cell-shortener.pipe.ts
@@ -9,13 +9,11 @@ export class TableCellShortenerPipe implements PipeTransform {
     if (value == undefined) {
       return value;
     }
-    if (
-      value.match('\\b\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b')
-    ) {
-      return value.substring(0, value.indexOf('.'));
+    if (value.match('\\b\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b')) {
+      return value.slice(0, Math.max(0, value.indexOf('.')));
     }
     if (value.length > 32) {
-      return value.substring(0, 32) + '...';
+      return value.slice(0, 32) + '...';
     }
     return value;
   }

--- a/src/app/shared/services/settings.service.ts
+++ b/src/app/shared/services/settings.service.ts
@@ -11,7 +11,11 @@ export class SettingsService {
 
   private loadSettingsFromLocalStorage(): void {
     this.setShowMultipleAtATime(localStorage.getItem(this.showMultipleAtATimeKey) === 'true');
-    this.setTableSpacing(Number(localStorage.getItem(this.tableSpacingKey)));
+    const tempTableSpacing = localStorage.getItem(this.tableSpacingKey);
+    //check if value is not greater than max allowed value to be set from dropdown
+    this.setTableSpacing(
+      tempTableSpacing == undefined ? 1 : Number(tempTableSpacing) <= 8 ? Number(tempTableSpacing) : 8
+    );
   }
 
   //Show multiple files in debug tree
@@ -28,11 +32,11 @@ export class SettingsService {
 
   //Table spacing settings
   private tableSpacingKey: string = 'tableSpacing';
-  private tableSpacing: number = 0;
+  private tableSpacing: number = 1;
   private tableSpacingSubject: Subject<number> = new ReplaySubject(1);
   public tableSpacingObservable: Observable<number> = this.tableSpacingSubject.asObservable();
 
-  public setTableSpacing(value: number = 0): void {
+  public setTableSpacing(value: number = 1): void {
     this.tableSpacing = value;
     this.tableSpacingSubject.next(value);
     localStorage.setItem(this.tableSpacingKey, String(value));

--- a/src/app/shared/services/settings.service.ts
+++ b/src/app/shared/services/settings.service.ts
@@ -9,6 +9,11 @@ export class SettingsService {
     this.loadSettingsFromLocalStorage();
   }
 
+  private loadSettingsFromLocalStorage(): void {
+    this.setShowMultipleAtATime(localStorage.getItem(this.showMultipleAtATimeKey) === 'true');
+    this.setTableSpacing(Number(localStorage.getItem(this.tableSpacingKey)));
+  }
+
   //Show multiple files in debug tree
   private showMultipleAtATimeKey: string = 'showMultipleFilesAtATime';
   private showMultipleAtATime: boolean = false;
@@ -21,7 +26,15 @@ export class SettingsService {
     localStorage.setItem(this.showMultipleAtATimeKey, String(this.showMultipleAtATime));
   }
 
-  private loadSettingsFromLocalStorage(): void {
-    this.setShowMultipleAtATime(localStorage.getItem(this.showMultipleAtATimeKey) === 'true');
+  //Table spacing settings
+  private tableSpacingKey: string = 'tableSpacing';
+  private tableSpacing: number = 0;
+  private tableSpacingSubject: Subject<number> = new ReplaySubject(1);
+  public tableSpacingObservable: Observable<number> = this.tableSpacingSubject.asObservable();
+
+  public setTableSpacing(value: number = 0): void {
+    this.tableSpacing = value;
+    this.tableSpacingSubject.next(value);
+    localStorage.setItem(this.tableSpacingKey, String(value));
   }
 }


### PR DESCRIPTION
Select all and deselect all buttons have been replaced with a checkbox in the table header.

Padding on table rows have been minimized to create more space.
Metadata table visible under the editor has been moved above it and can be shown or hidden with a button.
Table header names and column values have been shortened, hovering on the table header will still show the full name.

Table row spacing can be altered in settings, font size is also changed with the spacing.