### PR TITLE
Create non-standalone components by default

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -159,7 +159,10 @@
       "setParserOptionsProject": true
     },
     "@angular-eslint/schematics:library": {
-      "setParserOptionsProject": true
+      "setParserOptionsProject": true,
+    },
+    "@schematics/angular:component": {
+      "standalone": false
     }
   }
 }


### PR DESCRIPTION
Update angular.json so components are not set to standalone by default on creation