### PR TITLE
Set version to 0.0.55 for the next development cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wearefrank/ladybug",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config src/proxy.conf.json",


### PR DESCRIPTION
Ik maak deze PR voor het maken van de webjar. Dit om het risico op conflicten zo klein mogelijk te houden.