### PR TITLE
Change all references to ibissource organization to wearefrank

### DIFF
--- a/cypress/e2e/debug_download.cy.js
+++ b/cypress/e2e/debug_download.cy.js
@@ -26,7 +26,7 @@ describe('Debug tab download', function () {
     });
   });
 
-  // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of issue https://github.com/wearefrank/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
   xit('Download and upload table', function () {
     const downloadsFolder = Cypress.config('downloadsFolder');
@@ -88,7 +88,7 @@ describe('Debug tab download', function () {
     });
   });
 
-  // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of issue https://github.com/wearefrank/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
   xit('Download all open reports', function () {
     const downloadsFolder = Cypress.config('downloadsFolder');
@@ -150,19 +150,19 @@ describe('Debug tab download', function () {
     ).should('have.length', 1);
   });
 
-  // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of issue https://github.com/wearefrank/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
   xit('Download displayed report, from root node', function () {
     testDownloadFromNode(0);
   });
 
-  // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of issue https://github.com/wearefrank/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
   xit('Download displayed report, from start node', function () {
     testDownloadFromNode(1);
   });
 
-  // Fails because of issue https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of issue https://github.com/wearefrank/ladybug-frontend/issues/249.
   // TODO: Fix issue and re-enable test.
   xit('Download displayed report, from end node', function () {
     testDownloadFromNode(2);

--- a/cypress/e2e/testtab.cy.js
+++ b/cypress/e2e/testtab.cy.js
@@ -63,7 +63,7 @@ describe('About the Test tab', () => {
     cy.get('[data-cy-delete-modal="confirm"]').click();
   });
 
-  // Fails because of https://github.com/ibissource/ladybug-frontend/issues/249.
+  // Fails because of https://github.com/wearefrank/ladybug-frontend/issues/249.
   // There is also something strange with the beforeEach() here. After the
   // preparation two reports are expected in the test tab, but there is only one.
   xit('Download and upload', () => {

--- a/cypress/e2e/testtab_withOneReport.cy.js
+++ b/cypress/e2e/testtab_withOneReport.cy.js
@@ -20,7 +20,7 @@ describe('Tests with one report', () => {
     cy.get('[data-cy-nav-tab="debugTab"]').click();
   });
 
-  // May fail because of issue https://github.com/ibissource/ladybug-frontend/issues/250.
+  // May fail because of issue https://github.com/wearefrank/ladybug-frontend/issues/250.
   // TODO: Fix issue and re-enable test.
   xit('Test copy in testtab', () => {
     // cy.functions.testTabSelectReportNamed('Simple report');
@@ -85,7 +85,7 @@ describe('Tests with one report', () => {
       });
   });
 
-  // May fail because of issue https://github.com/ibissource/ladybug-frontend/issues/250.
+  // May fail because of issue https://github.com/wearefrank/ladybug-frontend/issues/250.
   // TODO: Fix issue and re-enable test.
   xit('Rerun, replace, succeed', () => {
     // cy.functions.testTabSelectReportNamed('Simple report');

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "https://github.com/ibissource/ladybug-frontend"
+    "url": "https://github.com/wearefrank/ladybug-frontend"
   },
   "packageManager": "yarn@4.0.2"
 }


### PR DESCRIPTION
Removed references to ibissource and changed them to wearefrank so any url is correct with the new organization.
Closes: #377.