### PR TITLE
Fix for the deleteAllTestReports command for Cypress tests

### DIFF
--- a/cypress/e2e/copying.cy.js
+++ b/cypress/e2e/copying.cy.js
@@ -1,14 +1,10 @@
 describe('Tests about copying', function() {
   beforeEach(() => {
-    cy.initializeApp();
+    cy.resetApp();
   });
 
-  afterEach(() => {
-    cy.clearDebugStore();
-    cy.get('[data-cy-nav-tab="testTab"]').click();
-    cy.get('[data-cy-test="selectAll"]').click();
-    cy.get('[data-cy-test="deleteSelected"]').click();
-    cy.get('[data-cy-delete-modal="confirm"]').click();
+  after(() => {
+    cy.resetApp();
   });
 
   it('Copy report to test tab', () => {

--- a/cypress/e2e/testtab_edit.cy.js
+++ b/cypress/e2e/testtab_edit.cy.js
@@ -1,6 +1,12 @@
 describe('Edit tests', () => {
   beforeEach(() => {
     cy.clearDebugStore();
+    cy.deleteAllTestReports();
+  });
+
+  afterEach(() => {
+    cy.clearDebugStore();
+    cy.deleteAllTestReports();
   });
 
   it('Edit report in test tab', () => {
@@ -36,7 +42,6 @@ describe('Edit tests', () => {
     cy.get('button:contains(Yes)').click();
     cy.get('[data-cy-nav-tab="testTab"]').click();
     cy.get('[data-cy-test="runAll"]').click();
-    cleanup()
   });
 
   it('Editing without pressing Edit produces error', () => {
@@ -47,7 +52,6 @@ describe('Edit tests', () => {
     cy.get('[data-cy-test-editor="save"]').should('have.length', 0);
     cy.get('[data-cy-test-editor="editor"]').click().type('x');
     cy.get('[data-cy-test-editor="readonlyLabel"]').contains('OFF');
-    cleanup()
   });
 
   it('When saving edit cancelled then original text kept and rerun fails', () => {
@@ -75,7 +79,6 @@ describe('Edit tests', () => {
     cy.navigateToTestTabAndWait();
     cy.get('[data-cy-test="runAll"]').click();
     // cy.get('span:contains(0/1 stubbed)').should('have.css', 'color').and('be.colored', 'red');
-    cy.deleteAllTestReports();
   });
 });
 
@@ -96,21 +99,4 @@ function prepareEdit() {
     .should('include.text', 'Simple report');
   // Wait until the tab has been rendered
   cy.get('.report-tab .jqx-tree-dropdown-root > li').should('have.length', 1);
-}
-
-
-function cleanup() {
-  cy.clearDebugStore();
-  cy.get('[data-cy-nav-tab="debugTab"] a').click();
-  // Wait for debug tab to be rendered
-  cy.wait(1000);
-  cy.get('[data-cy-nav-tab="testTab"]').click();
-  // Give UI time to build up the test tab.
-  cy.wait(1000);
-  cy.get('[data-cy-test="selectAll"]').click();
-  cy.get('[data-cy-test="deleteSelected"]').click();
-  cy.get('[data-cy-delete-modal="confirm"]').click();
-  cy.checkTestTableNumRows(0);
-  cy.get('[data-cy-nav-tab="debugTab"]').click();
-  cy.deleteAllTestReports();
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -40,7 +40,7 @@ Cypress.Commands.add('resetApp' as keyof Chainable, () => {
   );
   cy.deleteAllTestReports();
   cy.initializeApp();
-})
+});
 
 Cypress.Commands.add('navigateToTestTabAndWait' as keyof Chainable, () => {
   navigateToTabAndWait('test');
@@ -208,8 +208,8 @@ Cypress.Commands.add('deleteAllTestReports' as keyof Chainable, () => {
   cy.get('[data-cy-test="selectAll"]').click();
   cy.get('[data-cy-test="deleteSelected"]').click();
   console.log(Cypress.$('[data-cy-delete-modal="confirm"]'));
-  if (Cypress.$('[data-cy-delete-modal="confirm"]').length > 0) {
-    cy.get('[data-cy-delete-modal="confirm"]').should('exist');
+  if (Cypress.$('[data-cy-delete-modal="confirm"]').get('prevObject').length > 0) {
+    cy.get('[data-cy-delete-modal="confirm"]').click();
   }
   cy.visit('');
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -205,7 +205,8 @@ Cypress.Commands.add('enableShowMultipleInDebugTree' as keyof Chainable, () => {
 //Clear reports in test tab if any present
 Cypress.Commands.add('deleteAllTestReports' as keyof Chainable, () => {
   cy.navigateToTestTabAndWait();
-  cy.get('[data-cy-test="table"]').then((tbody: JQuery) => {
+  cy.get('[data-cy-test="table"]').should('exist');
+  cy.get('[data-cy-test="table"]', { timeout: 5000 }).then((tbody: JQuery) => {
     if (tbody.find('tr').length > 0) {
       cy.get('[data-cy-test="selectAll"]').click();
       cy.get('[data-cy-test="deleteSelected"]').click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -205,7 +205,6 @@ Cypress.Commands.add('enableShowMultipleInDebugTree' as keyof Chainable, () => {
 //Clear reports in test tab if any present
 Cypress.Commands.add('deleteAllTestReports' as keyof Chainable, () => {
   cy.navigateToTestTabAndWait();
-  cy.get('[data-cy-test="table"]').should('exist');
   cy.get('[data-cy-test="table"]', { timeout: 5000 }).then((tbody: JQuery) => {
     if (tbody.find('tr').length > 0) {
       cy.get('[data-cy-test="selectAll"]').click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -205,15 +205,15 @@ Cypress.Commands.add('enableShowMultipleInDebugTree' as keyof Chainable, () => {
 //Clear reports in test tab if any present
 Cypress.Commands.add('deleteAllTestReports' as keyof Chainable, () => {
   cy.navigateToTestTabAndWait();
-  cy.get('[data-cy-test="selectAll"]').click();
-  cy.get('[data-cy-test="deleteSelected"]').click();
-  console.log(Cypress.$('[data-cy-delete-modal="confirm"]'));
-  if (Cypress.$('[data-cy-delete-modal="confirm"]').get('prevObject').length > 0) {
-    cy.get('[data-cy-delete-modal="confirm"]').click();
-  }
+  cy.get('[data-cy-test="table"]').then((tbody: JQuery) => {
+    if (tbody.find('tr').length > 0) {
+      cy.get('[data-cy-test="selectAll"]').click();
+      cy.get('[data-cy-test="deleteSelected"]').click();
+      cy.get('[data-cy-delete-modal="confirm"]').click();
+    }
+  });
   cy.visit('');
 });
-
 
 Cypress.Commands.add('checkTableNumRows', n => {
   if (n === 0) {


### PR DESCRIPTION
The if-statement in the deleteAllTestReports would always give a length of 1 and it was called asynchronously. Because it was asynchronous it caused a race condition somehow, making the test flacky.

Applied resetApp method where applicable now that the deleteAllTestReports works (which is called in the resetApp method)