### PR TITLE
Feature: errors and warnings are now shown in a toast for a view storage

### DIFF
--- a/cypress/e2e/debug_show-warnings-and-errors.cy.ts
+++ b/cypress/e2e/debug_show-warnings-and-errors.cy.ts
@@ -1,0 +1,14 @@
+describe('Tests for showing errors and warnings', () => {
+  it('should show errors that occur for the storage of the current view', () => {
+    cy.initializeApp();
+    const apiCallAlias: string = 'warningsAndErrors';
+    cy.intercept({
+      method: 'GET',
+      hostname: 'localhost',
+      url: /\/warningsAndErrors\/*?/g,
+    }).as(apiCallAlias);
+    cy.get('[data-cy-change-view-dropdown]').select('Low level error demo view')
+    cy.wait(`@${apiCallAlias}`);
+    cy.get('[data-cy-toast="danger"]').should('contain', 'A simulated error').click();
+  });
+});

--- a/cypress/e2e/debug_show-warnings-and-errors.cy.ts
+++ b/cypress/e2e/debug_show-warnings-and-errors.cy.ts
@@ -7,8 +7,8 @@ describe('Tests for showing errors and warnings', () => {
       hostname: 'localhost',
       url: /\/warningsAndErrors\/*?/g,
     }).as(apiCallAlias);
-    cy.get('[data-cy-change-view-dropdown]').select('Low level error demo view')
+    cy.get('[data-cy-change-view-dropdown]').select('Low level error demo view');
     cy.wait(`@${apiCallAlias}`);
-    cy.get('[data-cy-toast="danger"]').should('contain', 'A simulated error').click();
+    cy.get('[data-cy-toast="danger"]').should('contain', 'A simulated error').should('contain', '...');
   });
 });

--- a/src/app/debug/debug.component.ts
+++ b/src/app/debug/debug.component.ts
@@ -77,8 +77,8 @@ export class DebugComponent implements OnInit, OnDestroy {
 
   showErrorsAndWarnings(value: string): void {
     if (value.length > this.toastService.TOASTER_LINE_LENGTH) {
-      const errorSnippet: string = value.slice(0, Math.max(0, this.toastService.TOASTER_LINE_LENGTH)).trim() + '...';
-      this.toastService.showDanger(errorSnippet, value);
+      const errorSnippet: string = value.slice(0, Math.max(0, this.toastService.TOASTER_LINE_LENGTH)).trim();
+      this.toastService.showDanger(`${errorSnippet}...`, value);
     } else {
       this.toastService.showDanger(value, value);
     }

--- a/src/app/shared/components/toast/toast.component.html
+++ b/src/app/shared/components/toast/toast.component.html
@@ -1,5 +1,5 @@
 <div class="toast-body">
-  <div *ngFor="let toast of toasts" class="my-2" data-cy-toast>
+  <div *ngFor="let toast of toasts" class="my-2" [attr.data-cy-toast]="toast.type">
     <div *ngIf="toast.type === 'info'">
       <ngb-toast [autohide]="true" [delay]="5000" (hidden)="close(toast)"
                  class="fade animate-show animate-hide">

--- a/src/app/shared/services/http.service.ts
+++ b/src/app/shared/services/http.service.ts
@@ -249,4 +249,11 @@ export class HttpService {
       })
       .pipe(catchError(this.handleError()));
   }
+
+  getWarningsAndErrors(storageName: string): Observable<string | undefined> {
+    const cleanStorageName = storageName.replaceAll(' ', '');
+    return this.http
+      .get(`api/report/warningsAndErrors/${cleanStorageName}`, { responseType: 'text' })
+      .pipe(catchError(this.handleError()));
+  }
 }

--- a/src/app/shared/services/toast.service.ts
+++ b/src/app/shared/services/toast.service.ts
@@ -8,6 +8,7 @@ import { Toast } from '../interfaces/toast';
 export class ToastService {
   private toastSubject: Subject<Toast> = new ReplaySubject(1);
   toastObservable: Observable<Toast> = this.toastSubject.asObservable();
+  readonly TOASTER_LINE_LENGTH: number = 37;
 
   constructor() {}
 


### PR DESCRIPTION
Like the old ladybug, errors and warnings that occur for the storage of a view are now shown in the frontend.
After conferring with @jacodg we decided a toast with a preview of the error was the best solution.
Closes: #379.

@wearefrank/frontend-reviewers 

Old:
![image](https://github.com/wearefrank/ladybug-frontend/assets/93487259/1d1dc1b3-2c4f-4a62-84c8-7b105a3bf4eb)

New:
![image](https://github.com/wearefrank/ladybug-frontend/assets/93487259/fce1521e-a1df-4710-9f4a-100798e41436)
![image](https://github.com/wearefrank/ladybug-frontend/assets/93487259/968ccda1-8a8c-4e80-ab7b-c759573ab193)
