### PR TITLE
changed all the string concats in ladybug-frontend to string template

### DIFF
--- a/src/app/compare/compare-tree/compare-tree.component.ts
+++ b/src/app/compare/compare-tree/compare-tree.component.ts
@@ -172,7 +172,7 @@ export class CompareTreeComponent {
   }
 
   redLabel(item: any) {
-    item.label = "<span style='color: red;'>" + item.label + '</span>';
+    item.label = `<span style='color: red;'>${item.label}</span>`;
   }
 
   iterateToMakeLabelsRed(leftItem: any, rightItem: any) {

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -511,13 +511,16 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   downloadReports(exportBinary: boolean, exportXML: boolean): void {
-    const queryString: string = this.tableSettings.reportMetadata
-      .filter((report) => report.checked)
-      .reduce((totalQuery: string, selectedReport: any) => totalQuery + 'id=' + selectedReport.storageId + '&', '');
-    if (queryString === '') {
-      this.toastService.showWarning('No reports selected to download');
-    } else {
+    const selectedReports = this.tableSettings.reportMetadata.filter((report) => report.checked);
+
+    if (selectedReports.length > 0) {
+      let queryString: string = '';
+      selectedReports.forEach((report) => {
+        queryString += `id=${report.storageId}&`;
+      });
       this.helperService.download(queryString, this.viewSettings.currentView.storageName, exportBinary, exportXML);
+    } else {
+      this.toastService.showWarning('No reports selected to download');
     }
   }
 
@@ -619,7 +622,7 @@ export class TableComponent implements OnInit, OnDestroy {
         longestViewName = key;
       }
     }
-    this.viewDropdownBoxWidth = longestViewName.length / 2 + 'rem';
+    this.viewDropdownBoxWidth = `${longestViewName.length / 2}rem`;
   }
 
   loadReportInProgressThreshold(): void {

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -515,9 +515,9 @@ export class TableComponent implements OnInit, OnDestroy {
 
     if (selectedReports.length > 0) {
       let queryString: string = '';
-      selectedReports.forEach((report) => {
+      for (let report of selectedReport) {
         queryString += `id=${report.storageId}&`;
-      });
+      }
       this.helperService.download(queryString, this.viewSettings.currentView.storageName, exportBinary, exportXML);
     } else {
       this.toastService.showWarning('No reports selected to download');

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -515,7 +515,7 @@ export class TableComponent implements OnInit, OnDestroy {
 
     if (selectedReports.length > 0) {
       let queryString: string = '';
-      for (let report of selectedReport) {
+      for (let report of selectedReports) {
         queryString += `id=${report.storageId}&`;
       }
       this.helperService.download(queryString, this.viewSettings.currentView.storageName, exportBinary, exportXML);

--- a/src/app/shared/services/helper.service.ts
+++ b/src/app/shared/services/helper.service.ts
@@ -12,15 +12,15 @@ export class HelperService {
 
   getImage(type: number, encoding: string, level: number): string {
     const even = this.determineEvenCheckpoint(level);
-    let img = 'assets/tree-icons/' + this.getCheckpointType(type);
+    let img = `assets/tree-icons/${this.getCheckpointType(type)}`;
     if (encoding === this.THROWABLE_ENCODER) {
       img += '-error';
     }
 
     if (even) {
-      return img + '-even.gif';
+      return `${img}-even.gif`;
     }
-    return img + '-odd.gif';
+    return `${img}-odd.gif`;
   }
 
   private determineEvenCheckpoint(level: number) {
@@ -90,9 +90,7 @@ export class HelperService {
   }
 
   download(queryString: string, storage: string, exportBinary: boolean, exportXML: boolean) {
-    window.open(
-      'api/report/download/' + storage + '/' + exportBinary + '/' + exportXML + '?' + queryString.slice(0, -1),
-    );
+    window.open(`api/report/download/${storage}/${exportBinary}/${exportXML}?${queryString.slice(0, -1)}`);
   }
 
   convertMessage(report: any): string {
@@ -120,7 +118,7 @@ export class HelperService {
 
   setButtonHtml(report: any, button: any, type: string, showConverted: boolean) {
     report.showConverted = showConverted;
-    button.target.title = 'Convert to ' + type;
+    button.target.title = `Convert to ${type}`;
     button.target.innerHTML = type;
   }
 
@@ -153,9 +151,9 @@ export class HelperService {
 
   getCheckpointOrStorageId(checkpoint: any, root: boolean): string {
     if (root && localStorage.getItem('showReportStorageIds')) {
-      return localStorage.getItem('showReportStorageIds') === 'true' ? '[' + checkpoint.storageId + '] ' : '';
+      return localStorage.getItem('showReportStorageIds') === 'true' ? `${[checkpoint.storageId]}` : '';
     } else if (localStorage.getItem('showCheckpointIds')) {
-      return localStorage.getItem('showCheckpointIds') === 'true' ? checkpoint.index + '. ' : '';
+      return localStorage.getItem('showCheckpointIds') === 'true' ? `${checkpoint.index}. ` : '';
     } else {
       return '';
     }
@@ -194,7 +192,7 @@ export class HelperService {
 
   findParent(currentNode: any, potentialParent: any, parentMap: any[]): any {
     if (currentNode.level < 0) {
-      currentNode.value.path = '[INVALID LEVEL ' + currentNode.value.level + '] ' + currentNode.value.name;
+      currentNode.value.path = `[INVALID LEVEL ${currentNode.value.level}] ${currentNode.value.name}`;
       currentNode.level = 0;
     } else if (currentNode.level - 1 == potentialParent.level) {
       // If the level difference is only 1, then the potential parent is the actual parent

--- a/src/app/shared/services/http.service.ts
+++ b/src/app/shared/services/http.service.ts
@@ -51,7 +51,7 @@ export class HttpService {
     metadataNames: string[],
     storage: string,
   ): Observable<Report[]> {
-    return this.http.get<Report[]>('api/metadata/' + storage + '/', {
+    return this.http.get<Report[]>(`api/metadata/${storage}/`, {
       params: {
         limit: limit,
         filterHeader: filterHeader,
@@ -62,7 +62,7 @@ export class HttpService {
   }
 
   getUserHelp(storage: string, metadataNames: string[]): Observable<Report[]> {
-    return this.http.get<Report[]>('api/metadata/' + storage + '/userHelp', {
+    return this.http.get<Report[]>(`api/metadata/${storage}/userHelp`, {
       params: {
         metadataNames: metadataNames,
       },
@@ -70,27 +70,27 @@ export class HttpService {
   }
 
   getMetadataCount(storage: string): Observable<number> {
-    return this.http.get<number>('api/metadata/' + storage + '/count').pipe(catchError(this.handleError()));
+    return this.http.get<number>(`api/metadata/${storage}/count`).pipe(catchError(this.handleError()));
   }
 
   getLatestReports(amount: number, storage: string): Observable<Report[]> {
     return this.http
-      .get<Report[]>('api/report/latest/' + storage + '/' + amount)
+      .get<Report[]>(`api/report/latest/${storage}/${amount}`)
       .pipe(tap(() => this.handleSuccess('Latest' + amount + 'reports opened!')))
       .pipe(catchError(this.handleError()));
   }
 
   getReportInProgress(index: number): Observable<Report> {
     return this.http
-      .get<Report>('api/testtool/in-progress/' + index)
-      .pipe(tap(() => this.handleSuccess('Opened report in progress with index [' + index + ']')))
+      .get<Report>(`api/testtool/in-progress/${index}`)
+      .pipe(tap(() => this.handleSuccess(`Opened report in progress with index [${index}]`)))
       .pipe(catchError(this.handleError()));
   }
 
   deleteReportInProgress(index: number): Observable<Report> {
     return this.http
       .delete<Report>('api/testtool/in-progress/' + index)
-      .pipe(tap(() => this.handleSuccess('Deleted report in progress with index [' + index + ']')))
+      .pipe(tap(() => this.handleSuccess(`Deleted report in progress with index [${index}]`)))
       .pipe(catchError(this.handleError()));
   }
 
@@ -99,7 +99,7 @@ export class HttpService {
   }
 
   getTestReports(metadataNames: string[], storage: string): Observable<TestListItem[]> {
-    return this.http.get<TestListItem[]>('api/metadata/' + storage + '/', {
+    return this.http.get<TestListItem[]>(`api/metadata/${storage}/`, {
       params: { metadataNames: metadataNames },
     });
   }
@@ -107,13 +107,7 @@ export class HttpService {
   getReport(reportId: string, storage: string): Observable<Report> {
     return this.http
       .get<Record<string, Report | string>>(
-        // eslint-disable-next-line sonarjs/no-duplicate-string
-        'api/report/' +
-          storage +
-          '/' +
-          reportId +
-          '/?xml=true&globalTransformer=' +
-          localStorage.getItem('transformationEnabled'),
+        `api/report/${storage}/${reportId}/?xml=true&globalTransformer=${localStorage.getItem('transformationEnabled')}`,
       )
       .pipe(
         map((e) => {
@@ -129,27 +123,27 @@ export class HttpService {
     return this.http
       .get<
         Record<string, CompareReport>
-      >('api/report/' + storage + '/?xml=true&globalTransformer=' + localStorage.getItem('transformationEnabled'), { params: { storageIds: reportIds } })
+      >(`api/report/${storage}/?xml=true&globalTransformer=${localStorage.getItem('transformationEnabled')}`, { params: { storageIds: reportIds } })
       .pipe(catchError(this.handleError()));
   }
 
   updateReport(reportId: string, body: Report, storage: string): Observable<void> {
     return this.http
-      .post('api/report/' + storage + '/' + reportId, body)
+      .post(`api/report/${storage}/${reportId}`, body)
       .pipe(tap(() => this.handleSuccess('Report updated!')))
       .pipe(catchError(this.handleError()));
   }
 
   copyReport(data: Record<string, string[]>, storage: string): Observable<void> {
     return this.http
-      .put('api/report/store/' + storage, data)
+      .put(`api/report/store/${storage}`, data)
       .pipe(tap(() => this.handleSuccess('Report copied!')))
       .pipe(catchError(this.handleError()));
   }
 
   updatePath(reportIds: string[], storage: string, map: UpdatePathSettings): Observable<void> {
     return this.http
-      .put('api/report/move/' + storage, map, {
+      .put(`api/report/move/${storage}`, map, {
         params: { storageIds: reportIds },
       })
       .pipe(catchError(this.handleError()));
@@ -166,7 +160,7 @@ export class HttpService {
 
   uploadReportToStorage(formData: FormData, storage: string): Observable<void> {
     return this.http
-      .post('api/report/upload/' + storage, formData, {
+      .post(`api/report/upload/${storage}`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       })
       .pipe(tap(() => this.handleSuccess('Report uploaded to storage!')))
@@ -191,7 +185,7 @@ export class HttpService {
 
   getTransformation(defaultTransformation: boolean): Observable<Record<string, string>> {
     return this.http
-      .get<Record<string, string>>('api/testtool/transformation/' + defaultTransformation)
+      .get<Record<string, string>>(`api/testtool/transformation/${defaultTransformation}`)
       .pipe(catchError(this.handleError()));
   }
 
@@ -214,7 +208,7 @@ export class HttpService {
 
   runDisplayReport(reportId: string, storage: string): Observable<Report> {
     return this.http
-      .put<Report>('api/runner/replace/' + storage + '/' + reportId, {
+      .put<Report>(`api/runner/replace/${storage}/${reportId}`, {
         headers: this.headers,
         observe: 'response',
       })
@@ -223,20 +217,20 @@ export class HttpService {
 
   cloneReport(storage: string, storageId: string, map: CloneReport): Observable<void> {
     return this.http
-      .post('api/report/move/' + storage + '/' + storageId, map)
+      .post(`api/report/move/${storage}/${storageId}`, map)
       .pipe(tap(() => this.handleSuccess('Report cloned!')))
       .pipe(catchError(this.handleError()));
   }
 
   deleteReport(reportIds: string[], storage: string): Observable<void> {
     return this.http
-      .delete('api/report/' + storage, { params: { storageIds: reportIds } })
+      .delete(`api/report/${storage}`, { params: { storageIds: reportIds } })
       .pipe(catchError(this.handleError()));
   }
 
   replaceReport(reportId: string, storage: string): Observable<void> {
     return this.http
-      .put('api/runner/replace/' + storage + '/' + reportId, {
+      .put(`api/runner/replace/${storage}/${reportId}`, {
         headers: this.headers,
       })
       .pipe(catchError(this.handleError()));
@@ -244,7 +238,7 @@ export class HttpService {
 
   getUnmatchedCheckpoints(storageName: string, storageId: string, viewName: string): Observable<void> {
     return this.http
-      .get('api/report/' + storageName + '/' + storageId + '/checkpoints/uids', {
+      .get(`api/report/${storageName}/${storageId}/checkpoints/uids`, {
         params: { view: viewName, invert: true },
       })
       .pipe(catchError(this.handleError()));

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -332,7 +332,7 @@ export class TestComponent implements OnInit, AfterViewInit {
 
   matches(report: any): boolean {
     let name = report.path + report.name;
-    return name.match(`(/)?${this.currentFilter}.*'`) != undefined;
+    return name.match(`(/)?${this.currentFilter}.*`) != undefined;
   }
 
   extractVariables(variables: string): string {

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -229,7 +229,7 @@ export class TestComponent implements OnInit, AfterViewInit {
     const selectedReports: Report[] = this.helperService.getSelectedReports(this.reports);
     if (selectedReports.length > 0) {
       let queryString: string = '';
-      for (let report of selectedReportsreport) {
+      for (let report of selectedReports) {
         queryString += `id=${report.storageId}&`;
       }
       this.helperService.download(queryString, this.currentView.storageName, true, false);

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -229,9 +229,9 @@ export class TestComponent implements OnInit, AfterViewInit {
     const selectedReports: Report[] = this.helperService.getSelectedReports(this.reports);
     if (selectedReports.length > 0) {
       let queryString: string = '';
-      selectedReports.forEach((report) => {
+      for (let report of selectedReportsreport) {
         queryString += `id=${report.storageId}&`;
-      });
+      }
       this.helperService.download(queryString, this.currentView.storageName, true, false);
     } else {
       this.toastService.showWarning('No Report Selected!');

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -226,12 +226,12 @@ export class TestComponent implements OnInit, AfterViewInit {
   }
 
   downloadSelected(): void {
-    const selectedReports = this.helperService.getSelectedReports(this.reports);
+    const selectedReports: Report[] = this.helperService.getSelectedReports(this.reports);
     if (selectedReports.length > 0) {
-      const queryString: string = selectedReports.reduce(
-        (totalQuery: string, selectedReport: any) => totalQuery + 'id=' + selectedReport.storageId + '&',
-        '',
-      );
+      let queryString: string = '';
+      selectedReports.forEach((report) => {
+        queryString += `id=${report.storageId}&`;
+      });
       this.helperService.download(queryString, this.currentView.storageName, true, false);
     } else {
       this.toastService.showWarning('No Report Selected!');
@@ -332,7 +332,7 @@ export class TestComponent implements OnInit, AfterViewInit {
 
   matches(report: any): boolean {
     let name = report.path + report.name;
-    return name.match('(/)?' + this.currentFilter + '.*') != undefined;
+    return name.match(`(/)?${this.currentFilter}.*'`) != undefined;
   }
 
   extractVariables(variables: string): string {


### PR DESCRIPTION
There were two functions (one in table.components, one in test.components) that had a string concat within an array.reduce call and after I changed the concat to a template, linter complained that array.reduce wasn't allowed and therefor i changed the code there.