### PR TITLE
fix: debug tree indentation for end point checkpoints

### DIFF
--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -23,6 +23,7 @@ import {
 import { ButtonComponent } from '../../shared/components/button/button.component';
 import { NgIf } from '@angular/common';
 import { Checkpoint } from '../../shared/interfaces/checkpoint';
+import { CheckpointType } from '../../shared/enums/checkpoint-type';
 
 @Component({
   selector: 'app-debug-tree',
@@ -155,35 +156,23 @@ export class DebugTreeComponent implements OnDestroy {
 
   //Ladybug reports don't have a parent-child structure for its checkpoints, this function creates that parent-child structure
   transformReportToHierarchyStructure(report: Report): Report {
-    const checkpoints = report.checkpoints;
-    let checkpointsTemplate: Checkpoint[] = [];
+    const checkpoints: Checkpoint[] = report.checkpoints;
+    const checkpointsTemplate: Checkpoint[] = [];
     let startpointCounter: number = 0;
-    let startPointList: Checkpoint[] = [checkpoints[0]];
+    const startPointList: Checkpoint[] = [checkpoints[0]];
     for (let i = 0; i < checkpoints.length; i++) {
-      checkpoints[i].icon = this.helperService.getImage(
-        checkpoints[i].type,
-        checkpoints[i].encoding,
-        checkpoints[i].level,
-      );
+      const checkpoint: Checkpoint = checkpoints[i];
+      checkpoint.icon = this.helperService.getImage(checkpoint.type, checkpoint.encoding, checkpoint.level);
       if (checkpointsTemplate.length === 0) {
         checkpointsTemplate.push(checkpoints[0]);
       } else {
-        if (checkpoints[i].type == 2) {
-          if (startpointCounter == 0) {
-            checkpointsTemplate.push(checkpoints[i]);
-            break;
-          }
-          startpointCounter--;
-          startPointList.splice(-1, 1);
-        }
-        let currentStartpoint = startPointList;
+        const currentStartpoint: Checkpoint[] = startPointList;
         if (!currentStartpoint[startPointList.length - 1].checkpoints) {
           currentStartpoint[startPointList.length - 1].checkpoints = [];
         }
-        currentStartpoint[startPointList.length - 1].checkpoints!.push(checkpoints[i]);
-
-        if (checkpoints[i].type == 1) {
-          startPointList.push(checkpoints[i]);
+        currentStartpoint[startPointList.length - 1].checkpoints!.push(checkpoint);
+        if (checkpoint.type == CheckpointType.Startpoint) {
+          startPointList.push(checkpoint);
           startpointCounter++;
         }
       }

--- a/src/app/shared/enums/checkpoint-type.ts
+++ b/src/app/shared/enums/checkpoint-type.ts
@@ -1,0 +1,23 @@
+export const enum CheckpointType {
+  Startpoint = 1,
+  Endpoint,
+  Abortpoint,
+  Inputpoint,
+  Outputpoint,
+  Infopoint,
+  ThreadStartpointError,
+  ThreadStartpoint,
+  ThreadEndpoint,
+}
+
+export const CHECKPOINT_TYPE_STRINGS: { [key in CheckpointType]: string } = {
+  [CheckpointType.Startpoint]: 'startpoint',
+  [CheckpointType.Endpoint]: 'endpoint',
+  [CheckpointType.Abortpoint]: 'abortpoint',
+  [CheckpointType.Inputpoint]: 'inputpoint',
+  [CheckpointType.Outputpoint]: 'outputpoint',
+  [CheckpointType.Infopoint]: 'infopoint',
+  [CheckpointType.ThreadStartpointError]: 'threadStartpoint-error',
+  [CheckpointType.ThreadStartpoint]: 'threadStartpoint',
+  [CheckpointType.ThreadEndpoint]: 'threadEndpoint',
+};

--- a/src/app/shared/interfaces/checkpoint.ts
+++ b/src/app/shared/interfaces/checkpoint.ts
@@ -1,3 +1,5 @@
+import { CheckpointType } from '../enums/checkpoint-type';
+
 export interface Checkpoint {
   encoding: string;
   estimatedMemoryUsage: number;
@@ -13,7 +15,7 @@ export interface Checkpoint {
   stubNotFound: string;
   stubbed: boolean;
   threadName: string;
-  type: number;
+  type: CheckpointType;
   typeAsString: string;
   uid: string;
   waitingForStream: boolean;

--- a/src/app/shared/pipes/checkpoint-type.pipe.ts
+++ b/src/app/shared/pipes/checkpoint-type.pipe.ts
@@ -1,13 +1,12 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { HelperService } from '../services/helper.service';
+import { CHECKPOINT_TYPE_STRINGS, CheckpointType } from '../enums/checkpoint-type';
 
 @Pipe({
   name: 'checkpointType',
   standalone: true,
 })
 export class CheckpointTypePipe implements PipeTransform {
-  constructor(private helperService: HelperService) {}
-  transform(type: number): string {
-    return this.helperService.getCheckpointType(type);
+  transform(type: CheckpointType): string {
+    return CHECKPOINT_TYPE_STRINGS[type];
   }
 }


### PR DESCRIPTION
Because the value for the type of checkpoint is sent as an integer starting at 1, I didn't see a way to use const string types as enums, that's why this solution goes againt our frontend conventions. I'm open to any suggestions

Closes #467.