### PR TITLE
Refactor implement types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,10 @@
   },
   "root": true,
   "ignorePatterns": [
-    "projects/**/*"
+    "projects/**/*",
+    "dist/**",
+    "target/**",
+    "node_modules/**"
   ],
   "overrides": [
     {

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -157,27 +157,20 @@ export class DebugTreeComponent implements OnDestroy {
   //Ladybug reports don't have a parent-child structure for its checkpoints, this function creates that parent-child structure
   transformReportToHierarchyStructure(report: Report): Report {
     const checkpoints: Checkpoint[] = report.checkpoints;
-    const checkpointsTemplate: Checkpoint[] = [];
-    let startpointCounter: number = 0;
-    const startPointList: Checkpoint[] = [checkpoints[0]];
-    for (let i = 0; i < checkpoints.length; i++) {
-      const checkpoint: Checkpoint = checkpoints[i];
+    let currentStartPoint: Checkpoint | undefined;
+    let transformedCheckpoints: Checkpoint[] = [];
+    for (const checkpoint of checkpoints) {
       checkpoint.icon = this.helperService.getImage(checkpoint.type, checkpoint.encoding, checkpoint.level);
-      if (checkpointsTemplate.length === 0) {
-        checkpointsTemplate.push(checkpoints[0]);
-      } else {
-        const currentStartpoint: Checkpoint[] = startPointList;
-        if (!currentStartpoint[startPointList.length - 1].checkpoints) {
-          currentStartpoint[startPointList.length - 1].checkpoints = [];
-        }
-        currentStartpoint[startPointList.length - 1].checkpoints!.push(checkpoint);
-        if (checkpoint.type == CheckpointType.Startpoint) {
-          startPointList.push(checkpoint);
-          startpointCounter++;
-        }
+      if (checkpoint.type === CheckpointType.Startpoint) {
+        currentStartPoint = { ...checkpoint, checkpoints: [] };
+        transformedCheckpoints.push(currentStartPoint);
+        continue;
+      }
+      if (currentStartPoint) {
+        currentStartPoint.checkpoints!.push(checkpoint);
       }
     }
-    report.checkpoints = checkpointsTemplate;
+    report.checkpoints = transformedCheckpoints;
     return report;
   }
 

--- a/src/app/debug/debug.component.html
+++ b/src/app/debug/debug.component.html
@@ -1,11 +1,18 @@
 <div class="box">
   <div class="row top">
     <div class="w-100 h-100">
-      <app-table (openReportEvent)="addReportToTree($event)" (viewChange)="onViewChange($event)"></app-table>
+      @if (views && currentView) {
+        <app-table
+          [views]="views"
+          [currentView]="currentView"
+          (openReportEvent)="addReportToTree($event)"
+          (viewChange)="onViewChange($event)"
+        ></app-table>
+      }
     </div>
   </div>
   <div class="border-bottom"></div>
-  <div #bottom id="bottom-half" class="row bottom mb-0 pb-0 w-100">
+  <div id="bottom-half" class="row bottom mb-0 pb-0 w-100">
     <app-report #reportComponent [newTab]="false" [currentView]="currentView"></app-report>
   </div>
 </div>

--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.html
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.html
@@ -1,5 +1,5 @@
 @if (shouldShowFilter) {
-  <div class="filter-vertical-panel" data-cy-debug="filter-side-drawer" @removeTrigger>
+  <div data-cy-debug="filter-side-drawer" class="filter-vertical-panel" @removeTrigger>
     <div class="panel-container">
       <h1 class="h1 filter-label">Filter</h1>
       <div class="filter-input-container">
@@ -11,7 +11,7 @@
                 class="form-control"
                 type="text"
                 data-cy-debug="tableFilter"
-                [title]="metadataName"
+                [title]="getTooltipSuggestion(metadataName)"
                 [ngModel]="filterService.getCurrentFilterContext().get(metadataName)"
                 [matAutocomplete]="auto"
                 [placeholder]="'Filter for ' + metadataName"
@@ -41,7 +41,8 @@
         }
       </div>
       <div class="btn-container">
-        <button class="close-filter-btn btn btn-info" data-cy-debug="close-filter-btn" (click)="closeFilter()">Close
+        <button class="close-filter-btn btn btn-info" data-cy-debug="close-filter-btn" (click)="closeFilter()">
+          Close
         </button>
         <button
           class="clear-filter-btn btn btn-info"

--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.spec.ts
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterSideDrawerComponent } from './filter-side-drawer.component';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('FilterSideDrawerComponent', () => {
   let component: FilterSideDrawerComponent;
@@ -10,7 +11,7 @@ describe('FilterSideDrawerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatAutocompleteModule, FormsModule, FilterSideDrawerComponent],
+      imports: [MatAutocompleteModule, FormsModule, FilterSideDrawerComponent, HttpClientTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FilterSideDrawerComponent);

--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.spec.ts
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.spec.ts
@@ -4,6 +4,7 @@ import { FilterSideDrawerComponent } from './filter-side-drawer.component';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { View } from '../../shared/interfaces/view';
 
 describe('FilterSideDrawerComponent', () => {
   let component: FilterSideDrawerComponent;
@@ -16,6 +17,7 @@ describe('FilterSideDrawerComponent', () => {
 
     fixture = TestBed.createComponent(FilterSideDrawerComponent);
     component = fixture.componentInstance;
+    component.currentView = { storageName: 'mockStorage', metadataNames: ['mockMetadata'] } as View;
     fixture.detectChanges();
   });
 

--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
@@ -1,10 +1,13 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FilterService } from './filter.service';
 import { Subscription } from 'rxjs';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FormsModule } from '@angular/forms';
 import { TitleCasePipe } from '@angular/common';
+import { View } from '../../shared/interfaces/view';
+import { Report } from '../../shared/interfaces/report';
+import { HttpService } from '../../shared/services/http.service';
 
 @Component({
   standalone: true,
@@ -23,20 +26,27 @@ import { TitleCasePipe } from '@angular/common';
   imports: [MatAutocompleteModule, FormsModule, TitleCasePipe],
 })
 export class FilterSideDrawerComponent implements OnDestroy, OnInit {
+  @Input({ required: true }) currentView!: View;
+
   protected shouldShowFilter!: boolean;
   protected metadataLabels!: string[];
   protected currentRecords: Map<string, Array<string>> = new Map<string, Array<string>>();
   protected metadataTypes!: Map<string, string>;
+  protected toolTipSuggestions?: Report[];
 
   shouldShowFilterSubscription?: Subscription;
   metadataLabelsSubscription?: Subscription;
   currentRecordsSubscription?: Subscription;
   metadataTypesSubscription?: Subscription;
 
-  constructor(protected filterService: FilterService) {}
+  constructor(
+    protected filterService: FilterService,
+    private httpService: HttpService,
+  ) {}
 
   ngOnInit(): void {
     this.setSubscriptions();
+    this.getFilterToolTips();
   }
 
   ngOnDestroy(): void {
@@ -67,6 +77,16 @@ export class FilterSideDrawerComponent implements OnDestroy, OnInit {
     this.metadataLabelsSubscription?.unsubscribe();
     this.currentRecordsSubscription?.unsubscribe();
     this.metadataTypesSubscription?.unsubscribe();
+  }
+
+  getFilterToolTips() {
+    if (this.currentView) {
+      this.httpService.getUserHelp(this.currentView.storageName, this.currentView.metadataNames).subscribe({
+        next: (response: Report[]) => {
+          this.toolTipSuggestions = response;
+        },
+      });
+    }
   }
 
   closeFilter(): void {

--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
@@ -32,12 +32,12 @@ export class FilterSideDrawerComponent implements OnDestroy, OnInit {
   protected metadataLabels!: string[];
   protected currentRecords: Map<string, Array<string>> = new Map<string, Array<string>>();
   protected metadataTypes!: Map<string, string>;
-  protected toolTipSuggestions?: Report[];
+  protected toolTipSuggestions?: Report;
 
-  shouldShowFilterSubscription?: Subscription;
-  metadataLabelsSubscription?: Subscription;
-  currentRecordsSubscription?: Subscription;
-  metadataTypesSubscription?: Subscription;
+  private shouldShowFilterSubscription?: Subscription;
+  private metadataLabelsSubscription?: Subscription;
+  private currentRecordsSubscription?: Subscription;
+  private metadataTypesSubscription?: Subscription;
 
   constructor(
     protected filterService: FilterService,
@@ -79,14 +79,10 @@ export class FilterSideDrawerComponent implements OnDestroy, OnInit {
     this.metadataTypesSubscription?.unsubscribe();
   }
 
-  getFilterToolTips() {
-    if (this.currentView) {
-      this.httpService.getUserHelp(this.currentView.storageName, this.currentView.metadataNames).subscribe({
-        next: (response: Report[]) => {
-          this.toolTipSuggestions = response;
-        },
-      });
-    }
+  getFilterToolTips(): void {
+    this.httpService
+      .getUserHelp(this.currentView.storageName, this.currentView.metadataNames)
+      .subscribe((response: Report) => (this.toolTipSuggestions = response));
   }
 
   closeFilter(): void {
@@ -99,5 +95,11 @@ export class FilterSideDrawerComponent implements OnDestroy, OnInit {
 
   removeFilter(metadataName: string): void {
     this.filterService.updateFilterContext(metadataName, '');
+  }
+
+  getTooltipSuggestion(key: string) {
+    if (this.toolTipSuggestions) {
+      return this.toolTipSuggestions[key as keyof Report];
+    }
   }
 }

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -1,6 +1,6 @@
 @if (tableSettings.tableLoaded) {
   <div data-cy-debug="root" class="row" id="tableContent">
-    <app-filter-side-drawer></app-filter-side-drawer>
+    <app-filter-side-drawer [currentView]="currentView"></app-filter-side-drawer>
     @if (this.showFilterError) {
       <div class="alert alert-danger" role="alert" data-cy-debug="filter-error-message">
         Filter Error: {{ this.handleFilterErrorContext() }}
@@ -10,7 +10,8 @@
       <button data-cy-debug="refresh" class="btn btn-info btn-table" title="Refresh" (click)="refresh()">
         <i class="fa fa-refresh"></i>
       </button>
-      <button data-cy-debug="openSettings" class="btn btn-info btn-table" title="Settings" (click)="openSettingsModal()">
+      <button data-cy-debug="openSettings" class="btn btn-info btn-table" title="Settings"
+              (click)="openSettingsModal()">
         <i class="fa fa-cog"></i>
       </button>
       <button data-cy-debug="filter" class="btn btn-info btn-table" title="Filter" (click)="toggleFilter()">
@@ -21,9 +22,15 @@
           <i class="fa fa-download px-2"></i><span class="caret"></span>
         </button>
         <div ngbDropdownMenu aria-labelledby="dropdownDownloadTable">
-          <button ngbDropdownItem (click)="downloadReports(true, true)">XML & Binary</button>
-          <button ngbDropdownItem (click)="downloadReports(false, true)">XML <i class="fa fa-info-circle" title="Only a binary file can be uploaded again"></i></button>
-          <button ngbDropdownItem (click)="downloadReports(true, false)">Binary</button>
+          <button ngbDropdownItem (click)="downloadReports(true, true)">
+            XML & Binary
+          </button>
+          <button ngbDropdownItem (click)="downloadReports(false, true)">
+            XML <i class="fa fa-info-circle" title="Only a binary file can be uploaded again"></i>
+          </button>
+          <button ngbDropdownItem (click)="downloadReports(true, false)">
+            Binary
+          </button>
         </div>
       </div>
       <button data-cy-debug="upload" id="UploadButton" class="btn btn-info my-2 mx-1 px-3"
@@ -31,7 +38,8 @@
         <i class="fa fa-upload"></i>
         <input #uploadFileTable type="file" id="uploadFileTable" (change)="uploadReports($event)">
       </button>
-      <button data-cy-debug="openSelected" class="btn btn-info btn-table" title="Open Selected Reports" (click)="openSelected()">
+      <button data-cy-debug="openSelected" class="btn btn-info btn-table" title="Open Selected Reports"
+              (click)="openSelected()">
         Open Selected
       </button>
       <button data-cy-debug="delete" class="btn btn-info btn-table" title="Refresh" (click)="deleteSelected()">
@@ -40,46 +48,60 @@
 
       <div class="input-group input-group-container">
         <input data-cy-debug="displayAmount" type="number" class="form-control input-field"
-               [ngModel]="tableSettings.displayAmount" (keydown.enter)="changeTableLimit($event)" (blur)="changeTableLimit($event)">
+               [ngModel]="tableSettings.displayAmount" (keydown.enter)="changeTableLimit($event)"
+               (blur)="changeTableLimit($event)">
         <div data-cy-debug="amountShown" class="input-group-append">
           <div class="input-group-text">/{{ metadataCount }}</div>
         </div>
       </div>
 
       <div class="my-2 mx-1 px-2">
-        <select data-cy-change-view-dropdown class="form-control" (change)="changeView($event)">
-          @for (view of viewSettings.views | keyvalue; track view) {
-            <option [style.width]="viewDropdownBoxWidth" [selected]="view.key === viewSettings.currentView.name" [value]="view.key">{{ view.key }}</option>
+        <select #dropdown data-cy-change-view-dropdown class="form-control" (change)="changeView(+dropdown.value)">
+          @for (view of views; track view.name; let index = $index) {
+            <option [style.width]="viewDropdownBoxWidth" [selected]="currentView.name === view.name"
+                    [value]="index">{{ view.name }}
+            </option>
           }
         </select>
       </div>
 
-      <div data-cy-debug-in-progress-counter class="btn btn-static my-2 mx-1 px-2"> Reports in progress: {{ tableSettings.numberOfReportsInProgress }}</div>
+      <div data-cy-debug-in-progress-counter class="btn btn-static my-2 mx-1 px-2"
+      >Reports in progress: {{ tableSettings.numberOfReportsInProgress }}
+      </div>
       @if (tableSettings.numberOfReportsInProgress > 0) {
         <div class="row">
-          <div class="btn btn-static my-2 mx-1 px-2"> Estimated memory usage of reports in progress: {{ tableSettings.estimatedMemoryUsage }} Bytes</div>
+          <div class="btn btn-static my-2 mx-1 px-2"> Estimated memory usage of reports in
+            progress: {{ tableSettings.estimatedMemoryUsage }} Bytes
+          </div>
           <div class="col input-group my-2 mx-1 px-2">
-            <input #openIndex type="number" min="0" class="form-control" data-cy-debug="openInProgressNo" [value]="tableSettings.numberOfReportsInProgress" [max]="tableSettings.numberOfReportsInProgress"/>
+            <input #openIndex type="number" min="0" class="form-control" data-cy-debug="openInProgressNo"
+                   [value]="tableSettings.numberOfReportsInProgress" [max]="tableSettings.numberOfReportsInProgress" />
             <div class="input-group-append">
-              <button data-cy-debug="openInProgress" class="btn btn-info" type="button" id="openReportInProgressButton" (click)="openReportInProgress(+openIndex.value)">Open</button>
+              <button data-cy-debug="openInProgress" class="btn btn-info" type="button" id="openReportInProgressButton"
+                      (click)="openReportInProgress(+openIndex.value)">Open
+              </button>
             </div>
           </div>
           <div class="col input-group my-2 mx-1 px-2">
-            <input #deleteIndex type="number" min="0" class="form-control" id="deleteInProgressNo" [value]="tableSettings.numberOfReportsInProgress" [max]="tableSettings.numberOfReportsInProgress"/>
+            <input #deleteIndex type="number" min="0" class="form-control" id="deleteInProgressNo"
+                   [value]="tableSettings.numberOfReportsInProgress" [max]="tableSettings.numberOfReportsInProgress" />
             <div class="input-group-append">
-              <button class="btn btn-info" type="button" id="deleteReportInProgressButton" (click)="deleteReportInProgress(+deleteIndex.value)"><i class="fa fa-trash"></i></button>
+              <button class="btn btn-info" type="button" id="deleteReportInProgressButton"
+                      (click)="deleteReportInProgress(+deleteIndex.value)"><i class="fa fa-trash"></i></button>
             </div>
           </div>
         </div>
       }
 
       @if (hasTimedOut) {
-        <h4 class="progress-report-timout">[One or more reports are in progress for more than {{ this.reportsInProgressThreshold / 1000 / 60 }} minutes]</h4>
+        <h4 class="progress-report-timout">[One or more reports are in progress for more
+          than {{ this.reportsInProgressThreshold / 1000 / 60 }} minutes]</h4>
       }
 
       @switch (getAmountOfReportsSelected()) {
         @case (1) {
-          <button data-cy-debug="openReportTab" class="btn btn-info btn-table" title="Open In New Tab" (click)="openReportInTab()">
+          <button data-cy-debug="openReportTab" class="btn btn-info btn-table" title="Open In New Tab"
+                  (click)="openReportInTab()">
             Open In New Tab
           </button>
         }
@@ -91,52 +113,58 @@
       }
       <app-active-filters class="ml-2" [activeFilters]="currentFilters" (click)="toggleFilter()"></app-active-filters>
     </div>
-    @if (!doneRetrieving) {
-      <div>
-        <mat-spinner mode="indeterminate" [diameter]="30"></mat-spinner>
-      </div>
-    }
-    @else {
-      <div data-cy-debug="table" class="table-responsive" id="metadataTable">
-        <table class="table mb-0" matSort [style.font-size]="getFontSize()" (matSortChange)="helperService.sortData($event, tableSettings.reportMetadata)">
-          <thead id="table-header">
-            <tr>
-              <th class="table-row-checkbox header-padding">
-                <input data-cy-debug="selectAll" type="checkbox" class="vertical-middle" title="Select all rows" [checked]="allRowsSelected" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()" (click)="selectAllRows()">
-              </th>
-              @for (header of viewSettings.currentView.metadataLabels; let index = $index; track header) {
-                <th class="table-id-cell header-cell header-padding"
-                    [attr.mat-sort-header]="index"
-                    [title]="header">
-                  {{ getShortenedTableHeaderNames(header) }}
-                </th>
+    <div data-cy-debug="table" class="table-responsive" id="metadataTable">
+      <table
+        class="table mb-0"
+        matSort [style.font-size]="getFontSize()"
+        (matSortChange)="helperService.sortData($event, tableSettings.reportMetadata)">
+        <thead id="table-header">
+        <tr>
+          <th class="table-row-checkbox header-padding">
+            <input
+              data-cy-debug="selectAll"
+              type="checkbox"
+              class="vertical-middle"
+              title="Select all rows"
+              [checked]="allRowsSelected"
+              [style.width]="getCheckBoxSize()"
+              [style.height]="getCheckBoxSize()"
+              (click)="selectAllRows()">
+          </th>
+          @for (header of currentView.metadataLabels; let index = $index; track header) {
+            <th class="table-id-cell header-cell header-padding"
+                [attr.mat-sort-header]="index"
+                [title]="header">
+              {{ getShortenedTableHeaderNames(header) }}
+            </th>
+          }
+        </tr>
+        </thead>
+        <tbody data-cy-debug="tableBody">
+          @for (row of tableSettings.reportMetadata.slice(0, tableSettings.displayAmount); let index = $index; track row.storageId) {
+            <tr class="table-row"
+                [ngClass]="{'highlight': row.storageId === selectedReportStorageId}"
+                [style.background-color]="getStatusColor(row)"
+                [attr.data-cy-record-table-index]="index"
+                (click)="openSelectedReport(row.storageId);"
+            >
+              <td class="table-row-checkbox" [style.padding]="getTableSpacing()">
+                <input type="checkbox" [checked]="row.checked" [style.width]="getCheckBoxSize()"
+                       [style.height]="getCheckBoxSize()" (click)="toggleCheck(row)">
+              </td>
+              @for (metadataName of currentView.metadataNames; track metadataName) {
+                <td
+                  class="table-cell"
+                  [style.padding]="getTableSpacing()"
+                  [title]="row[metadataName]">
+                  {{ row[metadataName]|tableCellShortener }}
+                </td>
               }
             </tr>
-          </thead>
-          <tbody data-cy-debug="tableBody">
-            @for (row of tableSettings.reportMetadata.slice(0, tableSettings.displayAmount); let index = $index; track row.storageId) {
-              <tr class="table-row"
-                  [ngClass]="{'highlight': row.storageId === selectedReportStorageId}"
-                  [style.background-color]="getStatusColor(row)"
-                  [attr.data-cy-record-table-index]="index"
-                  (click)="openSelectedReport(row.storageId);"
-              >
-                <td class="table-row-checkbox" [style.padding]="getTableSpacing()">
-                  <input type="checkbox" [checked]="row.checked" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()" (click)="toggleCheck(row)">
-                </td>
-                @for (metadataName of viewSettings.currentView.metadataNames; track metadataName) {
-                  <td
-                    class="table-cell"
-                    [style.padding]="getTableSpacing()"
-                    [title]="row[metadataName]">
-                    {{ row[metadataName]|tableCellShortener }}</td>
-                }
-              </tr>
-            }
-          </tbody>
-        </table>
-      </div>
-    }
+          }
+        </tbody>
+      </table>
+    </div>
   </div>
 }
 

--- a/src/app/debug/table/table.component.spec.ts
+++ b/src/app/debug/table/table.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableComponent } from './table.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { View } from '../../shared/interfaces/view';
 
 describe('TableComponent', () => {
   let component: TableComponent;
@@ -16,6 +17,11 @@ describe('TableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TableComponent);
     component = fixture.componentInstance;
+    component.currentView = {
+      storageName: 'mockStorage',
+      metadataNames: ['mockMetadata'],
+      metadataTypes: new Map(),
+    } as View;
     fixture.detectChanges();
   });
 

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -134,7 +134,6 @@ export class TableComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     localStorage.setItem('transformationEnabled', 'true');
     this.calculateViewDropDownWidth();
-    this.retrieveRecords();
     this.filterService.setMetadataTypes(this.currentView.metadataTypes);
     this.loadData();
     this.subscribeToObservables();
@@ -208,12 +207,13 @@ export class TableComponent implements OnInit, OnDestroy {
   loadData(): void {
     this.loadReportInProgressThreshold();
     this.loadReportInProgressSettings();
+    this.retrieveRecords();
   }
 
   loadMetadataCount(): void {
-    this.httpService.getMetadataCount(this.currentView.storageName).subscribe((count: number) => {
-      this.metadataCount = count;
-    });
+    this.httpService
+      .getMetadataCount(this.currentView.storageName)
+      .subscribe((count: number) => (this.metadataCount = count));
   }
 
   loadReportInProgressSettings(): void {

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -211,11 +211,9 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   loadMetadataCount(): void {
-    if (this.currentView) {
-      this.httpService.getMetadataCount(this.currentView.storageName).subscribe((count: number) => {
-        this.metadataCount = count;
-      });
-    }
+    this.httpService.getMetadataCount(this.currentView.storageName).subscribe((count: number) => {
+      this.metadataCount = count;
+    });
   }
 
   loadReportInProgressSettings(): void {
@@ -255,13 +253,11 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   toggleFilter(): void {
-    if (this.currentView) {
-      this.filterService.setMetadataLabels(this.currentView.metadataNames);
-      this.filterService.setMetadataTypes(this.currentView.metadataTypes);
-      this.tableSettings.showFilter = !this.tableSettings.showFilter;
-      this.filterService.setShowFilter(this.tableSettings.showFilter);
-      this.filterService.setCurrentRecords(this.tableSettings.uniqueValues);
-    }
+    this.filterService.setMetadataLabels(this.currentView.metadataNames);
+    this.filterService.setMetadataTypes(this.currentView.metadataTypes);
+    this.tableSettings.showFilter = !this.tableSettings.showFilter;
+    this.filterService.setShowFilter(this.tableSettings.showFilter);
+    this.filterService.setCurrentRecords(this.tableSettings.uniqueValues);
   }
 
   toggleCheck(report: any): void {
@@ -291,20 +287,19 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   getStatusColor(metadata: any): string {
-    if (this.currentView) {
-      let statusName = this.currentView.metadataNames.find((name: string) => {
-        return name.toLowerCase() === 'status';
-      });
-      if (statusName && metadata[statusName]) {
-        if (metadata[statusName].toLowerCase() === 'success') {
-          return '#c3e6cb';
-        } else if (metadata[statusName].toLowerCase() === 'null') {
-          return '#A9A9A9FF';
-        } else {
-          return '#f79c9c';
-        }
+    let statusName = this.currentView.metadataNames.find((name: string) => {
+      return name.toLowerCase() === 'status';
+    });
+    if (statusName && metadata[statusName]) {
+      if (metadata[statusName].toLowerCase() === 'success') {
+        return '#c3e6cb';
+      } else if (metadata[statusName].toLowerCase() === 'null') {
+        return '#A9A9A9FF';
+      } else {
+        return '#f79c9c';
       }
     }
+
     return 'none';
   }
 
@@ -313,18 +308,14 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   openReportInTab(): void {
-    if (this.currentView) {
-      const reportTab = this.tableSettings.reportMetadata.find((report) => report.checked);
-      this.httpService
-        .getReport(reportTab.storageId, this.currentView.storageName)
-        .subscribe((report: Report): void => {
-          const reportData: ReportData = {
-            report: report,
-            currentView: this.currentView!,
-          };
-          this.tabService.openNewTab(reportData);
-        });
-    }
+    const reportTab = this.tableSettings.reportMetadata.find((report) => report.checked);
+    this.httpService.getReport(reportTab.storageId, this.currentView.storageName).subscribe((report: Report): void => {
+      const reportData: ReportData = {
+        report: report,
+        currentView: this.currentView!,
+      };
+      this.tabService.openNewTab(reportData);
+    });
   }
 
   openSelected(): void {
@@ -342,12 +333,10 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   deleteSelected(): void {
-    if (this.currentView) {
-      const reportIds = this.helperService.getSelectedIds(this.tableSettings.reportMetadata);
-      this.httpService.deleteReport(reportIds, this.currentView.storageName).subscribe(() => {
-        this.retrieveRecords();
-      });
-    }
+    const reportIds = this.helperService.getSelectedIds(this.tableSettings.reportMetadata);
+    this.httpService.deleteReport(reportIds, this.currentView.storageName).subscribe(() => {
+      this.retrieveRecords();
+    });
   }
 
   selectAll(): void {
@@ -359,37 +348,35 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   compareTwoReports(): void {
-    if (this.currentView) {
-      let compareReports: any = {};
+    let compareReports: any = {};
+    const selectedReports: string[] = this.tableSettings.reportMetadata
+      .filter((report) => report.checked)
+      .map((report) => report.storageId);
 
-      const selectedReports: string[] = this.tableSettings.reportMetadata
-        .filter((report) => report.checked)
-        .map((report) => report.storageId);
-      this.httpService.getReports(selectedReports, this.currentView.storageName).subscribe({
-        next: (data) => {
-          const leftObject = data[selectedReports[0]];
-          const originalReport = leftObject.report;
-          originalReport.xml = leftObject.xml;
+    this.httpService.getReports(selectedReports, this.currentView.storageName).subscribe({
+      next: (data) => {
+        const leftObject = data[selectedReports[0]];
+        const originalReport = leftObject.report;
+        originalReport.xml = leftObject.xml;
 
-          const rightObject = data[selectedReports[1]];
-          const runResultReport = rightObject.report;
-          runResultReport.xml = rightObject.xml;
+        const rightObject = data[selectedReports[1]];
+        const runResultReport = rightObject.report;
+        runResultReport.xml = rightObject.xml;
 
-          const id = this.helperService.createCompareTabId(originalReport, runResultReport);
-          compareReports = {
-            id: id,
-            originalReport: originalReport,
-            runResultReport: runResultReport,
-            viewName: this.currentView.name,
-            nodeLinkStrategy: this.currentView.nodeLinkStrategy,
-          };
-        },
+        const id = this.helperService.createCompareTabId(originalReport, runResultReport);
+        compareReports = {
+          id: id,
+          originalReport: originalReport,
+          runResultReport: runResultReport,
+          viewName: this.currentView.name,
+          nodeLinkStrategy: this.currentView.nodeLinkStrategy,
+        };
+      },
 
-        complete: () => {
-          this.tabService.openNewCompareTab(compareReports);
-        },
-      });
-    }
+      complete: () => {
+        this.tabService.openNewCompareTab(compareReports);
+      },
+    });
   }
 
   changeFilter(filters: Map<string, string>): void {

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -89,7 +89,6 @@ export class TableComponent implements OnInit, OnDestroy {
 
   tableSettings: TableSettings = {
     reportMetadata: [],
-    metadataHeaders: [],
     tableLoaded: false,
     displayAmount: this.DEFAULT_DISPLAY_AMOUNT,
     showFilter: false,
@@ -136,7 +135,6 @@ export class TableComponent implements OnInit, OnDestroy {
     localStorage.setItem('transformationEnabled', 'true');
     this.calculateViewDropDownWidth();
     this.retrieveRecords();
-    this.getUserHelp();
     this.filterService.setMetadataTypes(this.currentView.metadataTypes);
     this.loadData();
     this.subscribeToObservables();
@@ -195,32 +193,13 @@ export class TableComponent implements OnInit, OnDestroy {
           catchError(this.httpService.handleError());
         },
       });
-
-    this.getUserHelp();
     this.loadMetadataCount();
-  }
-
-  getUserHelp(): void {
-    if (this.currentView) {
-      this.httpService.getUserHelp(this.currentView.storageName, this.currentView.metadataNames).subscribe({
-        next: (response: Report[]) => {
-          this.tableSettings.metadataHeaders = response;
-        },
-      });
-    }
-  }
-
-  clearFilters(): void {
-    this.tableSettings.filterValues = [];
-    this.tableSettings.filterHeaders = [];
-    this.retrieveRecords();
   }
 
   changeView(index: number): void {
     this.currentView = this.views[index];
     this.retrieveRecords();
     this.allRowsSelected = false;
-    this.clearFilters();
     this.debugReportService.changeView(this.currentView);
     this.filterService.setMetadataLabels(this.currentView.metadataLabels);
     this.viewChange.next(this.currentView);
@@ -440,8 +419,6 @@ export class TableComponent implements OnInit, OnDestroy {
 
   refresh(): void {
     this.filterService.setShowFilter(false);
-    this.tableSettings.reportMetadata = [];
-    this.tableSettings.tableLoaded = false;
     this.tableSettings.displayAmount = 10;
     this.loadData();
   }
@@ -577,12 +554,6 @@ export class TableComponent implements OnInit, OnDestroy {
       }
       return String(a).localeCompare(String(b));
     });
-  }
-
-  sortFilterList(): void {
-    for (let metadataLabel of this.currentView.metadataNames) {
-      this.currentFilters.set(metadataLabel.toLowerCase().replaceAll(' ', ''), '');
-    }
   }
 
   calculateViewDropDownWidth(): void {

--- a/src/app/shared/interfaces/table-settings.ts
+++ b/src/app/shared/interfaces/table-settings.ts
@@ -1,6 +1,5 @@
 export interface TableSettings {
   reportMetadata: any[];
-  metadataHeaders: any[];
   displayAmount: number;
   showFilter: boolean;
   filterHeaders: string[];

--- a/src/app/shared/interfaces/view.ts
+++ b/src/app/shared/interfaces/view.ts
@@ -6,4 +6,5 @@ export interface View {
   metadataNames: string[];
   nodeLinkStrategy: string;
   storageName: string;
+  name: string;
 }

--- a/src/app/shared/services/http.service.ts
+++ b/src/app/shared/services/http.service.ts
@@ -40,8 +40,19 @@ export class HttpService {
     this.toastService.showSuccess(message);
   }
 
-  getViews(): Observable<Record<string, View>> {
-    return this.http.get<Record<string, View>>('api/testtool/views').pipe(catchError(this.handleError()));
+  getViews(): Observable<View[]> {
+    return this.http
+      .get('api/testtool/views')
+      .pipe(catchError(this.handleError()))
+      .pipe(
+        map((data: Record<string, View>) => {
+          let views: View[] = [];
+          for (let [key, value] of Object.entries(data)) {
+            views.push({ ...value, name: key });
+          }
+          return views;
+        }),
+      );
   }
 
   getMetadataReports(

--- a/src/app/shared/services/http.service.ts
+++ b/src/app/shared/services/http.service.ts
@@ -72,8 +72,8 @@ export class HttpService {
     });
   }
 
-  getUserHelp(storage: string, metadataNames: string[]): Observable<Report[]> {
-    return this.http.get<Report[]>(`api/metadata/${storage}/userHelp`, {
+  getUserHelp(storage: string, metadataNames: string[]): Observable<Report> {
+    return this.http.get<Report>(`api/metadata/${storage}/userHelp`, {
       params: {
         metadataNames: metadataNames,
       },

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, OnInit, Component, EventEmitter, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { HttpService } from '../shared/services/http.service';
 import { CloneModalComponent } from './clone-modal/clone-modal.component';
 import { TestSettingsModalComponent } from './test-settings-modal/test-settings-modal.component';
@@ -15,8 +15,8 @@ import { ReportData } from '../shared/interfaces/report-data';
 import { NodeLinkStrategy } from '../shared/enums/compare-method';
 import { TestFolderTreeComponent } from './test-folder-tree/test-folder-tree.component';
 import { ToastComponent } from '../shared/components/toast/toast.component';
-import { NgIf, NgFor } from '@angular/common';
-import { ReactiveFormsModule, FormsModule, NgModel } from '@angular/forms';
+import { NgFor, NgIf } from '@angular/common';
+import { FormsModule, NgModel, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '../shared/components/button/button.component';
 import { TestListItem } from '../shared/interfaces/test-list-item';
 import { View } from '../shared/interfaces/view';
@@ -124,14 +124,15 @@ export class TestComponent implements OnInit, AfterViewInit {
   }
 
   loadData(path: string): void {
-    this.httpService.getViews().subscribe((views: Record<string, View>) => {
-      const defaultViewKey: string | undefined = Object.keys(views).find((view: string) => views[view].defaultView);
-      if (defaultViewKey) {
+    this.httpService.getViews().subscribe((views: View[]) => {
+      const defaultView: View | undefined = views.find((view: View) => view.defaultView);
+      console.log(defaultView);
+      /*if (defaultView) {
         const selectedView: View = views[defaultViewKey];
         if (selectedView.storageName) {
           this.currentView.targetStorage = selectedView.storageName;
         }
-      }
+      }*/
     });
     this.httpService.getTestReports(this.currentView.metadataNames, this.currentView.storageName).subscribe({
       next: (value: TestListItem[]) => {


### PR DESCRIPTION
One step of many to change the way components talk to each other and using types everywhere.
The state of the debug component is now passed to its children, updating when one of its children emits an event.
This means that data is now passed from parent to child instead of child1 to parent to child2.
Also did a small code cleanup.
Please only review what's been changed in this PR, a lot still needs to be refactored, which will be done in steps.