### PR TITLE
Fix: open same report

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-unicorn": "^54.0.0",
     "font-awesome": "^4.7.0",
     "monaco-editor": "0.44.0",
-    "ng-simple-file-tree": "^0.1.19",
+    "ng-simple-file-tree": "^0.1.20",
     "ngx-monaco-editor-v2": "17.0.1",
     "path": "^0.12.7",
     "popper.js": "^1.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 0.44.0
         version: 0.44.0
       ng-simple-file-tree:
-        specifier: ^0.1.19
-        version: 0.1.19(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3)
+        specifier: ^0.1.20
+        version: 0.1.20(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3)
       ngx-monaco-editor-v2:
         specifier: 17.0.1
         version: 17.0.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(monaco-editor@0.44.0)
@@ -4128,8 +4128,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  ng-simple-file-tree@0.1.19:
-    resolution: {integrity: sha512-WtoMPalo6oLAqouaH57OJSU0csIpqDbkR7fl4udTgZYpGS9/80WJV9W4wlwXD3qGpaRw13z/HepItlrHggK7Cg==}
+  ng-simple-file-tree@0.1.20:
+    resolution: {integrity: sha512-igfDnzrdL2Z91TbCWwxeohRQC5dzbGPIZwfGMXkpxihrl8rE+/pT3thV1UdmYBZC7nxIuTOyQ6bTnnJPlRe4og==}
     peerDependencies:
       '@angular/common': ^17.2.3
       '@angular/core': ^17.3.2
@@ -10441,7 +10441,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  ng-simple-file-tree@0.1.19(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3):
+  ng-simple-file-tree@0.1.20(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3):
     dependencies:
       '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0)
       '@angular/core': 18.1.1(rxjs@7.4.0)(zone.js@0.14.8)

--- a/src/app/debug/debug-tree/debug-tree.component.html
+++ b/src/app/debug/debug-tree/debug-tree.component.html
@@ -17,7 +17,7 @@
     #tree
     data-cy-debug-tree="root"
     childrenKey="checkpoints"
-    pathAttribute="uid"
+    [pathAttribute]="['name', 'storageId', 'uid']"
     [options]="treeOptions"
     (itemSelected)="selectReport($event)"
   />

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -49,7 +49,7 @@ export class DebugTreeComponent implements OnDestroy {
   showMultipleAtATimeSubscription!: Subscription;
 
   private _currentView: any;
-  private lastReport?: Report;
+  private lastReport?: Report | null;
 
   treeOptions: FileTreeOptions = {
     highlightOpenFolders: false,
@@ -136,6 +136,9 @@ export class DebugTreeComponent implements OnDestroy {
   }
 
   removeAllReportsButOne(): void {
+    if (this.tree) {
+      this.tree.clearItems();
+    }
     if (this.lastReport) {
       this.addReportToTree(this.lastReport);
     }
@@ -169,6 +172,7 @@ export class DebugTreeComponent implements OnDestroy {
   closeEntireTree(): void {
     this.closeEntireTreeEvent.emit();
     this.tree.clearItems();
+    this.lastReport = null;
   }
 
   expandAll(): void {

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -142,12 +142,15 @@ export class DebugTreeComponent implements OnDestroy {
   }
 
   addReportToTree(report: Report): void {
+    if (this.selectReportIfPresent(report)) {
+      return;
+    }
     this.lastReport = report;
     if (!this.showMultipleAtATime) {
       this.tree.clearItems();
     }
     const newReport: CreateTreeItem = new ReportHierarchyTransformer().transform(report);
-    const optional: OptionalParameters = { childrenKey: 'checkpoints', pathAttribute: 'uid' };
+    const optional: OptionalParameters = { childrenKey: 'checkpoints', pathAttributes: ['name', 'storageId', 'uid'] };
     const path: string = this.tree.addItem(newReport, optional);
     this.tree.selectItem(path);
     if (this.currentView) {
@@ -184,5 +187,16 @@ export class DebugTreeComponent implements OnDestroy {
   conditionalOpenFunction(item: CreateTreeItem): boolean {
     const type = item['type'];
     return type === undefined || type === 1 || type === 2;
+  }
+
+  selectReportIfPresent(report: Report): boolean {
+    for (let item of this.tree.getItems()) {
+      const treeReport = item.originalValue as Report;
+      if (treeReport.storageId === report.storageId) {
+        this.tree.selectItem(item.path);
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -176,14 +176,6 @@ export class DebugTreeComponent implements OnDestroy {
     this.tree.collapseAll();
   }
 
-  downloadReports(exportBinary: boolean, exportXML: boolean): void {
-    let queryString = '';
-    for (let treeReport of this.getTreeReports()) {
-      queryString += `id=${treeReport.storageId}&`;
-    }
-    this.helperService.download(queryString, this.currentView.storageName, exportBinary, exportXML);
-  }
-
   changeSearchTerm(event: KeyboardEvent): void {
     const term: string = (event.target as HTMLInputElement).value;
     this.tree.searchTree(term);


### PR DESCRIPTION
Clicking a report that's already openen in the debug-tree will now select it, instead of opening again.
If multiple reports are opened, clicking a node doesnt also select other nodes with the same name anymore.
Closes #37.
Closes #478.