### PR TITLE
Fix: double-click to open a report in the file tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-unicorn": "^54.0.0",
     "font-awesome": "^4.7.0",
     "monaco-editor": "0.44.0",
-    "ng-simple-file-tree": "^0.1.20",
+    "ng-simple-file-tree": "^0.1.22",
     "ngx-monaco-editor-v2": "17.0.1",
     "path": "^0.12.7",
     "popper.js": "^1.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 0.44.0
         version: 0.44.0
       ng-simple-file-tree:
-        specifier: ^0.1.20
-        version: 0.1.20(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3)
+        specifier: ^0.1.22
+        version: 0.1.22(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3)
       ngx-monaco-editor-v2:
         specifier: 17.0.1
         version: 17.0.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(monaco-editor@0.44.0)
@@ -4128,8 +4128,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  ng-simple-file-tree@0.1.20:
-    resolution: {integrity: sha512-igfDnzrdL2Z91TbCWwxeohRQC5dzbGPIZwfGMXkpxihrl8rE+/pT3thV1UdmYBZC7nxIuTOyQ6bTnnJPlRe4og==}
+  ng-simple-file-tree@0.1.22:
+    resolution: {integrity: sha512-rCE86sbwoaTiWdHASic4ynAIwrllmP4P76vnRuXtH7bxLF70x5UY5OBy3YicDmkG8EmG3DHbl9HbWO8DwYpxoA==}
     peerDependencies:
       '@angular/common': ^17.2.3
       '@angular/core': ^17.3.2
@@ -10441,7 +10441,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  ng-simple-file-tree@0.1.20(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3):
+  ng-simple-file-tree@0.1.22(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0))(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(bootstrap-icons@1.11.3):
     dependencies:
       '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.4.0)(zone.js@0.14.8))(rxjs@7.4.0)
       '@angular/core': 18.1.1(rxjs@7.4.0)(zone.js@0.14.8)


### PR DESCRIPTION
Previously you had to double click a node in the debug tree to expand or collapse it. 
Now you can click the chevron as well.
Closes #485.