### PR TITLE
fix: opening multiple reports at once with setting disabled

### DIFF
--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -122,7 +122,7 @@
                    [style.height]="getCheckBoxSize()" (click)="selectAllRows()">
           </th>
           <td mat-cell class="table-row-checkbox" *matCellDef="let row" [style.padding]="getTableSpacing()">
-            <input type="checkbox" [checked]="row.checked" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()" (click)="toggleCheck(row)">
+            <input type="checkbox" [checked]="row.checked" [style.width]="getCheckBoxSize()" [style.height]="getCheckBoxSize()" (click)="toggleCheck(row, $event)">
           </td>
         </ng-container>
 

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -338,14 +338,14 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   openSelected(): void {
+    if (this.getAmountOfReportsSelected() > 1 && !this.showMultipleFiles) {
+      this.toastService.showWarning(
+        'Please enable show multiple files in settings to open multiple files in the debug tree',
+      );
+      return;
+    }
     for (const report of this.tableSettings.reportMetadata) {
       if (report.checked) {
-        if (!this.showMultipleFiles) {
-          this.toastService.showWarning(
-            'Please enable show multiple files in settings to open multiple files in the debug tree',
-          );
-          break;
-        }
         this.openReport(report.storageId);
       }
     }

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -272,7 +272,8 @@ export class TableComponent implements OnInit, OnDestroy {
     this.filterService.setCurrentRecords(this.tableSettings.uniqueValues);
   }
 
-  toggleCheck(report: any): void {
+  toggleCheck(report: any, event: MouseEvent): void {
+    event.stopPropagation();
     report.checked = !report.checked;
     if (this.allRowsSelected && !report.checked) {
       this.allRowsSelected = false;
@@ -339,13 +340,13 @@ export class TableComponent implements OnInit, OnDestroy {
   openSelected(): void {
     for (const report of this.tableSettings.reportMetadata) {
       if (report.checked) {
-        this.openReport(report.storageId);
         if (!this.showMultipleFiles) {
           this.toastService.showWarning(
             'Please enable show multiple files in settings to open multiple files in the debug tree',
           );
           break;
         }
+        this.openReport(report.storageId);
       }
     }
   }


### PR DESCRIPTION
When trying to open multiple reports while the setting for opening multiple reports is disabled it no longer opens any reports.
Closes #486.