### PR TITLE
Table component sticky header

### DIFF
--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -146,7 +146,7 @@
         }
 
         <!--Values are passed to their respective header and row elements-->
-        <tr mat-header-row *matHeaderRowDef="getDisplayedColumnNames(currentView.metadataLabels)"></tr>
+        <tr mat-header-row *matHeaderRowDef="getDisplayedColumnNames(currentView.metadataLabels); sticky: true"></tr>
         <tr mat-row class="table-row"
             *matRowDef="let row; let rowIndex = index; columns: getDisplayedColumnNames(currentView.metadataLabels)"
             [ngClass]="{'highlight': row.storageId === selectedReportStorageId}"


### PR DESCRIPTION
closes #554 
A small fix so the headers stay visible on screen while scrolling down the table.