### PR TITLE
Fix: Report run error specification

### DIFF
--- a/src/app/shared/interfaces/test-list-item.ts
+++ b/src/app/shared/interfaces/test-list-item.ts
@@ -8,4 +8,5 @@ export interface TestListItem {
   storageId: number;
   variables?: string;
   reranReport?: ReranReport | null;
+  error?: string;
 }

--- a/src/app/test/test.component.html
+++ b/src/app/test/test.component.html
@@ -121,6 +121,11 @@
                       {{ report.reranReport.resultString }}
                     </span>
                   }
+                  @if (report.error) {
+                    <span style="color: red">
+                      {{ report.error }}
+                    </span>
+                  }
                 </td>
                 <td>
                   @if (report.reranReport) {

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -4,7 +4,7 @@ import { CloneModalComponent } from './clone-modal/clone-modal.component';
 import { TestSettingsModalComponent } from './test-settings-modal/test-settings-modal.component';
 import { TestResult } from '../shared/interfaces/test-result';
 import { ReranReport } from '../shared/interfaces/reran-report';
-import { catchError } from 'rxjs';
+import { catchError, Observable, of } from 'rxjs';
 import { Report } from '../shared/interfaces/report';
 import { HelperService } from '../shared/services/helper.service';
 import { DeleteModalComponent } from './delete-modal/delete-modal.component';
@@ -21,6 +21,7 @@ import { View } from '../shared/interfaces/view';
 import { OptionsSettings } from '../shared/interfaces/options-settings';
 import { ErrorHandling } from '../shared/classes/error-handling.service';
 import { BooleanToStringPipe } from '../shared/pipes/boolean-to-string.pipe';
+import { HttpErrorResponse } from '@angular/common/http';
 
 export const updatePathActionConst = ['move', 'copy'] as const;
 export type UpdatePathAction = (typeof updatePathActionConst)[number];
@@ -153,7 +154,11 @@ export class TestComponent implements OnInit {
         next: (response: TestResult): void => {
           report.reranReport = this.createReranReport(response);
         },
-        error: () => catchError(this.errorHandler.handleError()),
+        error: () =>
+          catchError((error: HttpErrorResponse): Observable<any> => {
+            report.error = error.message;
+            return of(error);
+          }),
       });
     } else {
       this.toastService.showWarning('Generator is disabled!');


### PR DESCRIPTION
Closes #429 
Error message is now shown in the test table instead of a toast, so it is clear which error correlates for the specific report.
