### PR TITLE
New data-cy tag for table rows

### DIFF
--- a/cypress/e2e/debug_aboutOpenedReports.cy.ts
+++ b/cypress/e2e/debug_aboutOpenedReports.cy.ts
@@ -30,9 +30,9 @@ describe('About opened reports', () => {
 
   it('Close all', () => {
     cy.enableShowMultipleInDebugTree();
-    cy.getTableBody().get('tr td:contains(Simple report)').first().click();
+    cy.getTableRows().find('td:contains(Simple report)').first().click();
     cy.checkFileTreeLength(1);
-    cy.getTableBody().get('tr td:contains("Another simple report")').first().click();
+    cy.getTableRows().find('td:contains("Another simple report")').first().click();
     cy.checkFileTreeLength(2);
     // Check sequence of opened reports. We expect "Simple report" first, then "Another simple report".
     cy.get('[data-cy-debug-tree="root"] > app-tree-item:nth-child(1) > div > .sft-item > .item-name').should(
@@ -49,7 +49,7 @@ describe('About opened reports', () => {
   it('Correct nesting in debug tree for report with infopoint', () => {
     cy.createReportWithInfopoint();
     cy.initializeApp();
-    cy.getTableBody().get('tr td:contains("Hide a checkpoint in blackbox view")').first().click();
+    cy.getTableRows().find('td:contains("Hide a checkpoint in blackbox view")').first().click();
     cy.checkFileTreeLength(1);
     cy.get(
       '[data-cy-debug-tree="root"] app-tree-item > div > div:contains("Hide this checkpoint") > div:contains("Hide this checkpoint") > app-tree-item > div > div:contains("Hide a checkpoint in blackbox view")',
@@ -65,7 +65,7 @@ describe('About opened reports', () => {
   it('Correct nesting in debug tree for report with multiple startpoints', () => {
     cy.createReportWithMultipleStartpoints();
     cy.initializeApp();
-    cy.getTableBody().get('tr td:contains("Multiple startpoints")').first().click();
+    cy.getTableRows().find('td:contains("Multiple startpoints")').first().click();
     cy.checkFileTreeLength(1);
     cy.get(
       '[data-cy-debug-tree="root"] app-tree-item > div > div:contains("Hello infopoint") > div:contains("Hello infopoint") > app-tree-item > div > div:contains("startpoint 2") > div:contains("startpoint 2") > app-tree-item  > div > div:contains("startpoint 2")',

--- a/cypress/e2e/debug_clickingInTableOpensReport.cy.ts
+++ b/cypress/e2e/debug_clickingInTableOpensReport.cy.ts
@@ -13,14 +13,14 @@ describe('Clicking a report', () => {
 
   it('Selecting report should show a tree', () => {
     cy.get('[data-cy-debug-tree="buttons"]').should('not.exist');
-    cy.getTableBody().find('tr').first().click();
+    cy.getTableRow(0).click();
     cy.get('[data-cy-debug-tree="buttons"]').should('be.visible');
   });
 
   it('Selecting report should show display', () => {
     cy.get('[data-cy-debug-editor="buttons"]').should('not.exist');
     cy.get('[data-cy-element-name="editor"]').should('not.exist');
-    cy.getTableBody().find('tr').first().click();
+    cy.getTableRow(0).click();
     cy.get('[data-cy-debug-editor="buttons"]').should('be.visible');
     cy.get('[data-cy-element-name="editor"]').should('be.visible');
   });

--- a/cypress/e2e/debug_clickingInTableOpensReport.cy.ts
+++ b/cypress/e2e/debug_clickingInTableOpensReport.cy.ts
@@ -13,14 +13,14 @@ describe('Clicking a report', () => {
 
   it('Selecting report should show a tree', () => {
     cy.get('[data-cy-debug-tree="buttons"]').should('not.exist');
-    cy.getTableRow(0).click();
+    cy.getTableRows().first().click();
     cy.get('[data-cy-debug-tree="buttons"]').should('be.visible');
   });
 
   it('Selecting report should show display', () => {
     cy.get('[data-cy-debug-editor="buttons"]').should('not.exist');
     cy.get('[data-cy-element-name="editor"]').should('not.exist');
-    cy.getTableRow(0).click();
+    cy.getTableRows().first().click();
     cy.get('[data-cy-debug-editor="buttons"]').should('be.visible');
     cy.get('[data-cy-element-name="editor"]').should('be.visible');
   });

--- a/cypress/e2e/debug_table.cy.ts
+++ b/cypress/e2e/debug_table.cy.ts
@@ -10,17 +10,17 @@ describe('Testing table', () => {
   afterEach(() => cy.resetApp());
 
   it('Sorting the table by column name', () => {
-    cy.getTableRow(0).contains("Simple report");
+    cy.getTableRows().first().contains("Simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
-    cy.getTableRow(0).contains("Another simple report");
+    cy.getTableRows().first().contains("Another simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
-    cy.getTableRow(0).contains("Simple report");
+    cy.getTableRows().first().contains("Simple report");
   });
 
   it('Refresh to reset table to default', () => {
-    cy.getTableRow(0).contains("Simple report");
+    cy.getTableRows().first().contains("Simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
     cy.get('[data-cy-debug="refresh"]').click()
-    cy.getTableRow(0).contains("Simple report");
+    cy.getTableRows().first().contains("Simple report");
   })
 });

--- a/cypress/e2e/debug_table.cy.ts
+++ b/cypress/e2e/debug_table.cy.ts
@@ -10,17 +10,17 @@ describe('Testing table', () => {
   afterEach(() => cy.resetApp());
 
   it('Sorting the table by column name', () => {
-    cy.getTableBody().find('tr').eq(0).contains("Simple report");
+    cy.getTableRow(0).contains("Simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
-    cy.getTableBody().find('tr').eq(0).contains("Another simple report");
+    cy.getTableRow(0).contains("Another simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
-    cy.getTableBody().find('tr').eq(0).contains("Simple report");
+    cy.getTableRow(0).contains("Simple report");
   });
 
   it('Refresh to reset table to default', () => {
-    cy.getTableBody().find('tr').eq(0).contains("Simple report");
+    cy.getTableRow(0).contains("Simple report");
     cy.get('[data-cy-debug="metadataLabel"]').eq(3).click();
     cy.get('[data-cy-debug="refresh"]').click()
-    cy.getTableBody().find('tr').eq(0).contains("Simple report");
+    cy.getTableRow(0).contains("Simple report");
   })
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -41,6 +41,7 @@ declare global {
       refreshApp(): Chainable;
       getTableBody(): Chainable;
       assertDebugTableLength(length: number): Chainable;
+      getTableRow(index: number): Chainable;
     }
   }
 }
@@ -203,6 +204,10 @@ Cypress.Commands.add('refreshApp' as keyof Chainable, (): void => {
 
 Cypress.Commands.add('getTableBody' as keyof Chainable, (): Chainable => {
   return cy.get('[data-cy-debug="tableBody"]').get('tbody');
+});
+
+Cypress.Commands.add('getTableRow' as keyof Chainable, (index: number): Chainable => {
+  return cy.get('[data-cy-debug="tableRow"]').eq(index);
 });
 
 Cypress.Commands.add('assertDebugTableLength' as keyof Chainable, (length: number): void => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -41,7 +41,7 @@ declare global {
       refreshApp(): Chainable;
       getTableBody(): Chainable;
       assertDebugTableLength(length: number): Chainable;
-      getTableRow(index: number): Chainable;
+      getTableRows(): Chainable;
     }
   }
 }
@@ -206,8 +206,8 @@ Cypress.Commands.add('getTableBody' as keyof Chainable, (): Chainable => {
   return cy.get('[data-cy-debug="tableBody"]').get('tbody');
 });
 
-Cypress.Commands.add('getTableRow' as keyof Chainable, (index: number): Chainable => {
-  return cy.get('[data-cy-debug="tableRow"]').eq(index);
+Cypress.Commands.add('getTableRows' as keyof Chainable, (): Chainable => {
+  return cy.get('[data-cy-debug="tableRow"]');
 });
 
 Cypress.Commands.add('assertDebugTableLength' as keyof Chainable, (length: number): void => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -39,7 +39,6 @@ declare global {
       clickRowInTable(index: number): Chainable;
       checkFileTreeLength(length: number): Chainable;
       refreshApp(): Chainable;
-      getTableBody(): Chainable;
       assertDebugTableLength(length: number): Chainable;
       getTableRows(): Chainable;
     }
@@ -189,7 +188,7 @@ Cypress.Commands.add('clickFirstFileInFileTree' as keyof Chainable, (): void => 
 });
 
 Cypress.Commands.add('clickRowInTable' as keyof Chainable, (index: number): void => {
-  cy.get('[data-cy-debug="tableBody"]').get('tbody').find('tr').eq(index).click();
+  cy.getTableRows().eq(index).click();
 });
 
 Cypress.Commands.add('checkFileTreeLength' as keyof Chainable, (length: number): void => {
@@ -202,18 +201,14 @@ Cypress.Commands.add('refreshApp' as keyof Chainable, (): void => {
   cy.wait('@apiCall').then(() => cy.log('All api requests have completed'));
 });
 
-Cypress.Commands.add('getTableBody' as keyof Chainable, (): Chainable => {
-  return cy.get('[data-cy-debug="tableBody"]').get('tbody');
-});
-
 Cypress.Commands.add('getTableRows' as keyof Chainable, (): Chainable => {
   return cy.get('[data-cy-debug="tableRow"]');
 });
 
 Cypress.Commands.add('assertDebugTableLength' as keyof Chainable, (length: number): void => {
   length === 0
-    ? cy.getTableBody().find('tr').should('not.exist')
-    : cy.getTableBody().find('tr').should('have.length', length);
+    ? cy.getTableRows().should('not.exist')
+    : cy.getTableRows().should('have.length', length);
 });
 
 function interceptGetApiCall(alias: string): void {

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -143,7 +143,7 @@
 
         <!--Values are passed to their respective header and row elements-->
         <tr mat-header-row *matHeaderRowDef="getDisplayedColumnNames(currentView.metadataLabels); sticky: true"></tr>
-        <tr mat-row class="table-row"
+        <tr data-cy-debug="tableRow" mat-row class="table-row"
             *matRowDef="let row; let rowIndex = index; columns: getDisplayedColumnNames(currentView.metadataLabels)"
             [ngClass]="{'highlight': row.storageId === selectedReportStorageId}"
             [attr.data-cy-record-table-index]="rowIndex"

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -103,7 +103,7 @@
         than {{ this.reportsInProgressThreshold / 1000 / 60 }} minutes]</h4>
     }
     <div data-cy-debug="table" class="table-responsive table-container">
-      <table data-cy-debug="tableBody" mat-table class="table mb-0" matSort [style.font-size]="fontSize" [dataSource]="tableDataSource">
+      <table mat-table class="table mb-0" matSort [style.font-size]="fontSize" [dataSource]="tableDataSource">
         <!--Header and row container for checkboxes-->
         <ng-container matColumnDef="select">
           <th mat-header-cell class="table-row-checkbox header-padding" *matHeaderCellDef>


### PR DESCRIPTION
closes #579 
Added a new data-cy tag that only includes the rows in the debug table that have a report in them.
Refactored commands in cypress tests with a new getTableRows command which returns a list of every report in the table.

Removed the data-cy tableBody tag as it was no longer being used anywhere.