### PR TITLE
Compare tab window using full height

### DIFF
--- a/src/app/compare/compare.component.css
+++ b/src/app/compare/compare.component.css
@@ -26,3 +26,7 @@
   padding-top: 1.25rem;
   height: 100%;
 }
+
+.diff-editor {
+  height: 100%;
+}

--- a/src/app/compare/compare.component.ts
+++ b/src/app/compare/compare.component.ts
@@ -39,6 +39,7 @@ export class CompareComponent implements AfterViewInit, OnInit {
     readOnly: true,
     renderSideBySide: true,
     automaticLayout: true,
+    scrollBeyondLastLine: false,
   };
   protected originalModel: DiffEditorModel = { code: '', language: 'xml' };
   protected modifiedModel: DiffEditorModel = { code: '', language: 'xml' };


### PR DESCRIPTION
Closes #585 
After doing some research, here's my conclusion on the matter.
The monaco diff editor cannot be adjusted in height and should not. It always needs a set height. Therefore I made it so the entire remaining height that the element can use is filled up by the element.

For a better look, I added the following line to the monaco editor options:
`scrollBeyondLastLine: false`

Could not find a way to remove the big scrollbar on the right. This should be researched further at a later time.