### PR TITLE
fix: hidden checkpoints stay hidden in blackbox view after report update

### DIFF
--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -194,6 +194,7 @@ export class DebugTreeComponent implements OnDestroy {
     if (lastSelectedReport) {
       this.tree.selectItem(lastSelectedReport.path);
     }
+    this.hideOrShowCheckpointsBasedOnView(this._currentView);
   }
 
   async getNewReport(storageId: number): Promise<FileTreeItem> {


### PR DESCRIPTION
Closes #637.
After conferring with @jacodg, we decided that this solution made sense the most.
Checkpoints hidden by black box view in the debug tree, stay hidden after updating the report.