### PR TITLE
Refactor: Remove unnecessary cy.wait calls

### DIFF
--- a/cypress/e2e/debug/labels.cy.ts
+++ b/cypress/e2e/debug/labels.cy.ts
@@ -11,7 +11,6 @@ describe('Test labels', () => {
     cy.initializeApp();
     cy.get('[data-cy-debug="selectAll"]').click();
     cy.get('[data-cy-debug="openSelected"]').click();
-    cy.wait(300);
     cy.checkFileTreeLength(1);
     testTreeView('Message is null');
   });

--- a/cypress/e2e/debug/refresh.cy.ts
+++ b/cypress/e2e/debug/refresh.cy.ts
@@ -11,7 +11,6 @@ describe('Refresh', () => {
     cy.assertDebugTableLength(0);
     cy.createReport();
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(1);
     cy.get('[data-cy-debug="amountShown"]').invoke('text').should('contain', '1');
   });

--- a/cypress/e2e/debug/reportGenerator.cy.ts
+++ b/cypress/e2e/debug/reportGenerator.cy.ts
@@ -15,7 +15,6 @@ describe('Report generator', () => {
     cy.assertDebugTableLength(0);
     cy.createReport();
     cy.refreshApp();
-    cy.wait(100);
     cy.assertDebugTableLength(1);
     cy.get('[data-cy-debug="openSettings"]').click();
     cy.get('[role=dialog]').should('be.visible');
@@ -27,7 +26,6 @@ describe('Report generator', () => {
     // Without waiting, the test could succeed because we would count the number of reports
     // before refresh.
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(1);
     cy.get('[data-cy-debug="openSettings"]').click();
     cy.get('[role=dialog]').should('be.visible');
@@ -36,7 +34,6 @@ describe('Report generator', () => {
     cy.contains('Settings saved');
     cy.createOtherReport();
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(2);
   });
 });

--- a/cypress/e2e/debug/runningReports.cy.ts
+++ b/cypress/e2e/debug/runningReports.cy.ts
@@ -31,7 +31,6 @@ describe('With running reports', () => {
   it('Open running reports', () => {
     cy.get('[data-cy-debug-in-progress-counter]').should('contain.text', 'Reports in progress: 2');
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(0);
     cy.checkFileTreeLength(0);
     cy.get('[data-cy-debug="openInProgressNo"]').type('{backspace}1');

--- a/cypress/e2e/debug/toast.cy.ts
+++ b/cypress/e2e/debug/toast.cy.ts
@@ -9,7 +9,6 @@ describe('Test toast window', () => {
     cy.assertDebugTableLength(0);
     cy.createReport();
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.get('[data-cy-toast]').contains('Data loaded!');
     cy.assertDebugTableLength(1);
   });

--- a/cypress/e2e/debug/transformation.cy.ts
+++ b/cypress/e2e/debug/transformation.cy.ts
@@ -23,7 +23,6 @@ describe('Tests for report transformation', () => {
     cy.get('[data-cy-settings="saveChanges"]').click();
     cy.createOtherReport();
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(1).click();
     cy.checkFileTreeLength(1);
     // We test that the top node was not selected before.

--- a/cypress/e2e/test/testtab.cy.ts
+++ b/cypress/e2e/test/testtab.cy.ts
@@ -74,15 +74,9 @@ function copyTheReportsToTestTab() {
   // be stable before we go on with the test. Without this guard, the test
   // was flaky because the selectIfNotSelected() custom command accessed
   // a detached DOM element.
-  cy.wait(100);
   cy.checkFileTreeLength(2);
-  cy.wait(100);
   cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(0).find('.item-name').eq(0).click();
-  cy.wait(100);
   cy.debugTreeGuardedCopyReport('Simple report', 3, 'first');
-  cy.wait(100);
   cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(1).find('.item-name').eq(0).click();
-  cy.wait(100);
   cy.debugTreeGuardedCopyReport('Another simple report', 3, 'second');
-  cy.wait(1000);
 }

--- a/cypress/e2e/transformation.cy.ts
+++ b/cypress/e2e/transformation.cy.ts
@@ -23,7 +23,6 @@ describe('Report transformation', () => {
     cy.get('[data-cy-settings="saveChanges"]').click();
     cy.createOtherReport();
     cy.get('[data-cy-debug="refresh"]').click();
-    cy.wait(100);
     cy.assertDebugTableLength(1).click();
     cy.checkFileTreeLength(1);
     // We test that the top node was not selected before.


### PR DESCRIPTION
Removed unnecessary cy.wait calls to make cypress tests faster