### PR TITLE
fix: folder tree in test tab

### DIFF
--- a/cypress/e2e/test/testtab.cy.ts
+++ b/cypress/e2e/test/testtab.cy.ts
@@ -14,24 +14,25 @@ describe('Test the Test tab', () => {
   afterEach(() => cy.resetApp());
 
   it('Should delete one report at a time with deleteSelected button', () => {
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    // cy.get('[data-cy-test="toggleSelectAll"]').click();
     cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="reportChecked"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableReportsAre(['Simple report']);
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    // cy.get('[data-cy-test="toggleSelectAll"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
   });
 
   it('Should delete all tests with deleteSelected button', () => {
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    // cy.get('[data-cy-test="toggleSelectAll"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableNumRows(0);
   });
 
   it('Should not open delete modal when clicking on deleteSelected button and there are no tests selected', () => {
+    cy.get('[data-cy-test="toggleSelectAll"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.checkTestTableNumRows(2);
     cy.get('[data-cy-test="toggleSelectAll"]').click();
@@ -41,7 +42,7 @@ describe('Test the Test tab', () => {
 
   it('Should delete all tests with deleteAll button', () => {
     cy.checkTestTableNumRows(2);
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    // cy.get('[data-cy-test="toggleSelectAll"]').click();
     cy.get('[data-cy-test="deleteAll"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableNumRows(0);
@@ -74,15 +75,15 @@ function copyTheReportsToTestTab() {
   // be stable before we go on with the test. Without this guard, the test
   // was flaky because the selectIfNotSelected() custom command accessed
   // a detached DOM element.
-  cy.wait(100);
+
   cy.checkFileTreeLength(2);
-  cy.wait(100);
+
   cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(0).find('.item-name').eq(0).click();
-  cy.wait(100);
+
   cy.debugTreeGuardedCopyReport('Simple report', 3, 'first');
-  cy.wait(100);
+
   cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(1).find('.item-name').eq(0).click();
-  cy.wait(100);
+
   cy.debugTreeGuardedCopyReport('Another simple report', 3, 'second');
-  cy.wait(1000);
+
 }

--- a/src/app/shared/interfaces/test-list-item.ts
+++ b/src/app/shared/interfaces/test-list-item.ts
@@ -11,5 +11,4 @@ export interface TestListItem {
   extractedVariables?: string;
   reranReport?: ReranReport | null;
   error?: string;
-  showReport?: boolean;
 }

--- a/src/app/test/test-folder-tree/test-folder-tree.component.html
+++ b/src/app/test/test-folder-tree/test-folder-tree.component.html
@@ -1,2 +1,1 @@
-<ng-simple-tree #tree [options]="treeOptions" (itemSelected)="changeFolderEvent.next($event.name)"></ng-simple-tree>
-
+<ng-simple-tree #tree [options]="treeOptions" (itemSelected)="changeFolderEvent.next($event.path)"></ng-simple-tree>

--- a/src/app/test/test-folder-tree/test-folder-tree.component.ts
+++ b/src/app/test/test-folder-tree/test-folder-tree.component.ts
@@ -57,7 +57,7 @@ export class TestFolderTreeComponent {
     }
 
     const nextRoutePart = routeParts[0];
-    let newFolder: CreateTreeItem | null = this.getChildForNextRoutePart(nextRoutePart, currentLocation);
+    let newFolder: CreateTreeItem | undefined = currentLocation.children?.find((child) => child.name === nextRoutePart);
     currentLocation.children ??= [];
 
     if (!newFolder) {
@@ -70,16 +70,5 @@ export class TestFolderTreeComponent {
     }
 
     this.createFolderForRemainingPath(itemToAdd, routeParts.slice(1), newFolder);
-  }
-
-  getChildForNextRoutePart(routePart: string, currentLocation: CreateTreeItem) {
-    if (currentLocation.children) {
-      for (const child of currentLocation.children) {
-        if (child.name === routePart) {
-          return child;
-        }
-      }
-    }
-    return null;
   }
 }

--- a/src/app/test/test-table/test-table.component.html
+++ b/src/app/test/test-table/test-table.component.html
@@ -77,6 +77,6 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr data-cy-test="tableRow" mat-row *matRowDef="let report; columns: displayedColumns;" [hidden]="!report.showReport"></tr>
+    <tr data-cy-test="tableRow" mat-row *matRowDef="let report; columns: displayedColumns;"></tr>
   </table>
 </div>

--- a/src/app/test/test-table/test-table.component.ts
+++ b/src/app/test/test-table/test-table.component.ts
@@ -119,9 +119,15 @@ export class TestTableComponent implements OnChanges {
 
   getFullPaths(): void {
     for (const report of this.reports) {
-      report.fullPath = report.path
-        ? `${report.path.replace(this.currentFilter, '')}${report.name}`
-        : `/${report.name}`;
+      if (report.path) {
+        let transformedPath = report.path.replace(this.currentFilter, '');
+        if (transformedPath.startsWith('/')) {
+          transformedPath = transformedPath.slice(1);
+        }
+        report.fullPath = `${transformedPath}${report.name}`;
+      } else {
+        report.fullPath = `/${report.name}`;
+      }
     }
   }
 
@@ -151,9 +157,15 @@ export class TestTableComponent implements OnChanges {
       );
       this.tabService.openNewCompareTab({
         id: tabId,
-        originalReport: { ...report.reranReport.originalReport, storageName: this.testReportsService.storageName },
+        originalReport: {
+          ...report.reranReport.originalReport,
+          storageName: this.testReportsService.storageName,
+        },
         // Temporary fix until https://github.com/wearefrank/ladybug/issues/283 is fixed
-        runResultReport: { ...report.reranReport.runResultReport, storageName: 'Debug' },
+        runResultReport: {
+          ...report.reranReport.runResultReport,
+          storageName: 'Debug',
+        },
       });
     }
   }

--- a/src/app/test/test.component.html
+++ b/src/app/test/test.component.html
@@ -37,7 +37,7 @@
     <p>Generator is {{ generatorEnabled|booleanToString: 'enabled':'disabled' }}</p>
 
     <app-test-table
-      [reports]="reports" [currentFilter]="currentFilter"
+      [reports]="filteredReports" [currentFilter]="currentFilter"
       [showStorageIds]="showStorageIds" (runEvent)="run($event)">
     </app-test-table>
   </div>

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -54,9 +54,11 @@ export class TestComponent implements OnInit {
 
   private updatePathAction: UpdatePathAction = 'move';
   @ViewChild(CloneModalComponent) cloneModal!: CloneModalComponent;
-  @ViewChild(TestSettingsModalComponent) testSettingsModal!: TestSettingsModalComponent;
+  @ViewChild(TestSettingsModalComponent)
+  testSettingsModal!: TestSettingsModalComponent;
   @ViewChild(DeleteModalComponent) deleteModal!: DeleteModalComponent;
-  @ViewChild(TestFolderTreeComponent) testFileTreeComponent!: TestFolderTreeComponent;
+  @ViewChild(TestFolderTreeComponent)
+  testFileTreeComponent!: TestFolderTreeComponent;
   @ViewChild('moveToInput', { read: NgModel }) moveToInputModel!: NgModel;
   @ViewChild(TestTableComponent) testTableComponent!: TestTableComponent;
 
@@ -74,7 +76,6 @@ export class TestComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadData();
-    this.matches();
     localStorage.removeItem('generatorEnabled');
   }
 
@@ -110,7 +111,7 @@ export class TestComponent implements OnInit {
         this.reports = value;
         if (this.testFileTreeComponent) {
           this.testFileTreeComponent.setData(this.reports);
-          this.testFileTreeComponent.selectItem(path ?? this.testFileTreeComponent.rootFolder.name);
+          this.testFileTreeComponent.tree.selectItem(path ?? this.testFileTreeComponent.rootFolder.name);
         }
         this.matches();
         this.refresh();
@@ -275,7 +276,10 @@ export class TestComponent implements OnInit {
     const reportIds: number[] = this.helperService.getSelectedIds(this.reports);
     if (reportIds.length > 0) {
       const path: string = this.transformPath(this.moveToInputModel.value);
-      const map: UpdatePathSettings = { path: path, action: this.updatePathAction };
+      const map: UpdatePathSettings = {
+        path: path,
+        action: this.updatePathAction,
+      };
       this.httpService
         .updatePath(reportIds, this.testReportsService.storageName, map)
         .pipe(catchError(this.errorHandler.handleError()))
@@ -297,10 +301,7 @@ export class TestComponent implements OnInit {
   }
 
   changeFilter(filter: string): void {
-    this.currentFilter = filter === this.testFileTreeComponent.rootFolder.name ? '' : this.transformPath(filter);
-    for (const report of this.reports) {
-      report.checked = report.showReport ?? false;
-    }
+    this.currentFilter = filter === this.testFileTreeComponent.rootFolder.path ? '' : this.transformPath(filter);
     this.matches();
   }
 
@@ -319,9 +320,7 @@ export class TestComponent implements OnInit {
       report.showReport = false;
       if (report.path === null) report.path = '';
       const name: string = report.path + report.name;
-      if (new RegExp(`(/)?${this.currentFilter}.*`).test(name)) {
-        report.showReport = true;
-      }
+      report.checked = report.showReport = new RegExp(`(/)?${this.currentFilter}.*`).test(name);
     }
   }
 


### PR DESCRIPTION
Previously folders in the test tab did not update correctly and also just didn't work correctly.
Folder tree will now update as soon as a report is moved.
Folders are now also sorted alphabetically.
Closes #595 
Closes #320 