### PR TITLE
fix: indentation and icons for thread checkpoints

### DIFF
--- a/src/app/shared/classes/report-hierarchy-transformer.ts
+++ b/src/app/shared/classes/report-hierarchy-transformer.ts
@@ -15,9 +15,13 @@ export class ReportHierarchyTransformer {
       checkpoint.icon = iconData.path;
       checkpoint.iconClass = iconData.cssClasses;
 
-      if (checkpoint.type === CheckpointType.Startpoint) {
+      if (checkpoint.type === CheckpointType.Startpoint || checkpoint.type === CheckpointType.ThreadStartpoint) {
         this.handleStartpoint(checkpoint);
-      } else if (checkpoint.type === CheckpointType.Endpoint || checkpoint.type === CheckpointType.Abortpoint) {
+      } else if (
+        checkpoint.type === CheckpointType.Endpoint ||
+        checkpoint.type === CheckpointType.Abortpoint ||
+        checkpoint.type === CheckpointType.ThreadEndpoint
+      ) {
         this.handleEndpoint(checkpoint);
       } else {
         this.handleIntermediatePoint(checkpoint);
@@ -70,6 +74,7 @@ export class ReportHierarchyTransformer {
       iconData.cssClasses += '-error';
     }
     iconData.cssClasses += level % 2 == 0 ? '-even' : '-odd';
+    console.log(iconData);
     return iconData;
   }
 }

--- a/src/app/shared/classes/report-hierarchy-transformer.ts
+++ b/src/app/shared/classes/report-hierarchy-transformer.ts
@@ -74,7 +74,6 @@ export class ReportHierarchyTransformer {
       iconData.cssClasses += '-error';
     }
     iconData.cssClasses += level % 2 == 0 ? '-even' : '-odd';
-    console.log(iconData);
     return iconData;
   }
 }

--- a/src/app/shared/enums/checkpoint-type.ts
+++ b/src/app/shared/enums/checkpoint-type.ts
@@ -12,24 +12,44 @@ export const enum CheckpointType {
   ThreadEndpoint,
 }
 
+const checkPointClass = 'tree-checkpoint';
+
 export const CHECKPOINT_TYPE_STRINGS: { [key in CheckpointType]: IconData } = {
   //For the css classes, the tree-checkpoint should be at the end so that 'even' or 'odd' can be added to the class name; 'tree-checkpoint-even'.
-  [CheckpointType.Startpoint]: { path: 'assets/tree-icons/startpoint.svg', cssClasses: 'tree-checkpoint' },
-  [CheckpointType.Endpoint]: { path: 'assets/tree-icons/startpoint.svg', cssClasses: 'endpoint tree-checkpoint' },
-  [CheckpointType.Abortpoint]: { path: 'assets/tree-icons/abortpoint.svg', cssClasses: 'tree-checkpoint' },
-  [CheckpointType.Inputpoint]: { path: 'assets/tree-icons/inputpoint.svg', cssClasses: 'tree-checkpoint' },
-  [CheckpointType.Outputpoint]: { path: 'assets/tree-icons/inputpoint.svg', cssClasses: 'endpoint tree-checkpoint' },
-  [CheckpointType.Infopoint]: { path: 'assets/tree-icons/infopoint.svg', cssClasses: 'tree-checkpoint' },
+  [CheckpointType.Startpoint]: {
+    path: 'assets/tree-icons/startpoint.svg',
+    cssClasses: checkPointClass,
+  },
+  [CheckpointType.Endpoint]: {
+    path: 'assets/tree-icons/startpoint.svg',
+    cssClasses: `endpoint ${checkPointClass}`,
+  },
+  [CheckpointType.Abortpoint]: {
+    path: 'assets/tree-icons/abortpoint.svg',
+    cssClasses: checkPointClass,
+  },
+  [CheckpointType.Inputpoint]: {
+    path: 'assets/tree-icons/inputpoint.svg',
+    cssClasses: checkPointClass,
+  },
+  [CheckpointType.Outputpoint]: {
+    path: 'assets/tree-icons/inputpoint.svg',
+    cssClasses: `endpoint ${checkPointClass}`,
+  },
+  [CheckpointType.Infopoint]: {
+    path: 'assets/tree-icons/infopoint.svg',
+    cssClasses: checkPointClass,
+  },
   [CheckpointType.ThreadStartpointError]: {
     path: 'assets/tree-icons/threadStartPoint.svg',
-    cssClasses: 'tree-checkpoint-error',
+    cssClasses: `${checkPointClass}-error`,
   },
   [CheckpointType.ThreadStartpoint]: {
     path: 'assets/tree-icons/threadStartPoint.svg',
-    cssClasses: 'endpoint tree-checkpoint',
+    cssClasses: checkPointClass,
   },
   [CheckpointType.ThreadEndpoint]: {
     path: 'assets/tree-icons/threadStartPoint.svg',
-    cssClasses: 'endpoint tree-checkpoint',
+    cssClasses: `endpoint ${checkPointClass}`,
   },
 };


### PR DESCRIPTION
Indentation and icons for thread checkpoints are now correct in the tree
Closes #673 
Previously:
![image](https://github.com/user-attachments/assets/52ca658b-33d2-4778-b657-c435a704cdab)

Now:
![image](https://github.com/user-attachments/assets/74751c0f-1d6e-4b06-8f9b-b80c26d70038)
