### PR TITLE
feat: added hierarchy lines to show node indentation in tree view

### DIFF
--- a/cypress/e2e/debug/aboutOpenedReports.cy.ts
+++ b/cypress/e2e/debug/aboutOpenedReports.cy.ts
@@ -15,13 +15,13 @@ describe('About opened reports', () => {
     cy.get('[data-cy-debug="openSelected"]').click();
     // Each of the two reports has three lines.
     cy.checkFileTreeLength(2);
-    cy.get('[data-cy-debug-tree="root"] app-tree-item > div').should('contain', 'Simple report');
+    cy.get('[data-cy-debug-tree="root"] app-tree-item > div').should('contain.text', 'Simple report');
     cy.get('[data-cy-debug-tree="root"] app-tree-item > div > div:contains(Simple report)')
       .first()
       .selectIfNotSelected();
     cy.get('[data-cy-debug-editor="close"]').click();
     cy.get('[data-cy-debug-tree="root"] > app-tree-item .item-name')
-      .should('contain', 'Another simple report')
+      .should('contain.text', 'Another simple report')
       .eq(0)
       .click();
     cy.get('[data-cy-debug-tree="closeAll"]').click();
@@ -36,12 +36,12 @@ describe('About opened reports', () => {
     cy.checkFileTreeLength(2);
     // Check sequence of opened reports. We expect "Simple report" first, then "Another simple report".
     cy.get('[data-cy-debug-tree="root"] > app-tree-item:nth-child(1) > div > .sft-item > .item-name').should(
-      'have.text',
+      'contain.text',
       'Simple report',
     );
     cy.get('[data-cy-debug-tree="root"] > app-tree-item:nth-child(2) > div > .sft-item > .item-name')
       .eq(0)
-      .should('have.text', 'Another simple report');
+      .should('contain.text', 'Another simple report');
     cy.get('[data-cy-debug-tree="closeAll"]').click();
     cy.get('[data-cy-debug-tree="root"] app-tree-item').should('not.exist');
   });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-unicorn": "^55.0.0",
     "font-awesome": "^4.7.0",
     "monaco-editor": "0.52.0",
-    "ng-simple-file-tree": "^0.1.27",
+    "ng-simple-file-tree": "^0.1.28",
     "ngx-monaco-editor-v2": "17.0.1",
     "path": "^0.12.7",
     "prettier": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 0.52.0
         version: 0.52.0
       ng-simple-file-tree:
-        specifier: ^0.1.27
-        version: 0.1.27(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(bootstrap-icons@1.11.3)
+        specifier: ^0.1.28
+        version: 0.1.28(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(bootstrap-icons@1.11.3)
       ngx-monaco-editor-v2:
         specifier: 17.0.1
         version: 17.0.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(monaco-editor@0.52.0)
@@ -3993,8 +3993,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  ng-simple-file-tree@0.1.27:
-    resolution: {integrity: sha512-XMtmRBzEhfFFpzjH/J628wJreP6Tr6+5O6gc/RgFQEC1NMRjF7we5UT7SdyJ2Mc+W9D8UIGWVRR1/qR9EBMpzA==}
+  ng-simple-file-tree@0.1.28:
+    resolution: {integrity: sha512-R70UalZwJgiuf8fqlF1FpChusqUzxU8yi54VTl3eMdlWWQ/A+iWjKTk/6lwPImkNHOubcWQZMxstCsCV+NP7bA==}
     peerDependencies:
       '@angular/common': ^17.2.3
       '@angular/core': ^17.3.2
@@ -10132,7 +10132,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  ng-simple-file-tree@0.1.27(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(bootstrap-icons@1.11.3):
+  ng-simple-file-tree@0.1.28(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(bootstrap-icons@1.11.3):
     dependencies:
       '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1)
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.10)

--- a/src/app/compare/compare-tree/compare-tree.component.ts
+++ b/src/app/compare/compare-tree/compare-tree.component.ts
@@ -43,6 +43,9 @@ export class CompareTreeComponent {
     folderBehaviourOnClick: 'select',
     expandAllFolders: true,
     determineIconClass: SimpleFileTreeUtil.conditionalCssClass,
+    hierarchyLines: {
+      vertical: true,
+    },
   };
 
   rightTreeOptions: FileTreeOptions = {

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -52,6 +52,9 @@ export class DebugTreeComponent implements OnDestroy {
   private lastReport?: Report | null;
 
   treeOptions: FileTreeOptions = {
+    hierarchyLines: {
+      vertical: true,
+    },
     highlightOpenFolders: false,
     folderBehaviourOnClick: 'select',
     doubleClickToOpenFolders: false,

--- a/src/app/test/test-folder-tree/test-folder-tree.component.ts
+++ b/src/app/test/test-folder-tree/test-folder-tree.component.ts
@@ -19,6 +19,9 @@ export class TestFolderTreeComponent {
     path: '',
   };
   treeOptions: FileTreeOptions = {
+    hierarchyLines: {
+      vertical: true,
+    },
     folderBehaviourOnClick: 'select',
     doubleClickToOpenFolders: false,
     expandAllFolders: true,


### PR DESCRIPTION
Hierarchy lines have been added to tree view on all tabs to show node indentation 

before:
![image](https://github.com/user-attachments/assets/e2327ac2-597b-4b6e-b925-44110037eb86)
after:
![image](https://github.com/user-attachments/assets/f9ca4790-cd8e-4a6e-81d6-2aaa9e8bcf94)
