### PR TITLE
fix: open first checkpoint instead of root node when opening report in debug tab

### DIFF
--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -147,10 +147,21 @@ export class DebugTreeComponent implements OnDestroy {
       this.tree.clearItems();
     }
     const newReport: CreateTreeItem = new ReportHierarchyTransformer().transform(report);
-    const path: string = this.tree.addItem(newReport);
-    this.tree.selectItem(path);
+    const rootNodePath: string = this.tree.addItem(newReport);
+    this.selectFirstCheckpoint(rootNodePath);
     if (this._currentView) {
       this.hideOrShowCheckpointsBasedOnView(this._currentView);
+    }
+  }
+
+  private selectFirstCheckpoint(rootNodePath: string) {
+    const last = this.tree.items.length - 1;
+    const lastAdded = this.tree.items[last];
+    if (lastAdded.children) {
+      const firstCheckpoint = lastAdded.children[0];
+      this.tree.selectItem(firstCheckpoint.path);
+    } else {
+      this.tree.selectItem(rootNodePath);
     }
   }
 


### PR DESCRIPTION
When clicking a report in the debug tab, previously the root node was selected and opened in the editor:
![image](https://github.com/user-attachments/assets/e85ffa9a-f59b-4abd-99b9-43ffbe590d31)

Now it opens the first checkpoint instead:
![image](https://github.com/user-attachments/assets/3c06a20e-d049-4970-afde-a690f50af6ac)
