### PR TITLE
Fix: readonly storage

### DIFF
--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -245,7 +245,7 @@ export class TableComponent implements OnInit, OnDestroy {
 
   changeView(view: View): void {
     this.currentView = view;
-    this.retrieveRecords();
+    this.loadData();
     this.filterService.setMetadataLabels(this.currentView.metadataNames);
     this.viewChange.next(this.currentView);
   }

--- a/src/app/report/edit-display/edit-display.component.css
+++ b/src/app/report/edit-display/edit-display.component.css
@@ -35,3 +35,7 @@
   margin: 0.25rem 0.25rem 0.75rem 0.25rem;
   gap: 0 0.25rem;
 }
+
+select:disabled {
+  cursor: not-allowed;
+}

--- a/src/app/report/edit-display/edit-display.component.html
+++ b/src/app/report/edit-display/edit-display.component.html
@@ -38,8 +38,9 @@
           {{ metadataTableVisible|booleanToString:'Hide' :'Show' }} metadata
         </button>
         <app-toggle-button
+          #editToggleButton
           data-cy-report="toggleEdit"
-          [labels]="{on: 'Edit', off:'View'}"
+          [labels]="{on: 'Edit', off: 'View'}"
           [value]="editingEnabled"
           (valueChanged)="toggleEditMode($event)"
         ></app-toggle-button>

--- a/src/app/report/edit-display/edit-display.component.html
+++ b/src/app/report/edit-display/edit-display.component.html
@@ -73,8 +73,8 @@
 
 
         @if (ReportUtil.isReport(selectedNode)) {
-          <div class="w-fit mx-1 my-0">
-            <select class="form-control" [(ngModel)]="stubStrategy"
+          <div class="w-fit mx-1 my-0" [title]="reportStubStrategy.disabled ? 'This report is in a readonly storage, copy it to the test tab to make changes' : null">
+            <select #reportStubStrategy class="form-control" [disabled]="!ReportUtil.isFromCrudStorage(selectedNode)" [(ngModel)]="stubStrategy"
                     (ngModelChange)="updateReportStubStrategy($event)">
               @for (strategy of StubStrategy.report; track strategy) {
                 <option [ngValue]="strategy" [selected]="selectedNode.stubStrategy === strategy">{{ strategy }}
@@ -83,8 +83,9 @@
             </select>
           </div>
         } @else if (ReportUtil.isCheckPoint(selectedNode) && ReportUtil.hasValidUid(selectedNode.uid)) {
-          <div class="w-fit mx-1 my-0">
-            <select class="form-control" [(ngModel)]="stub" (ngModelChange)="updateCheckpointStubStrategy($event)">
+          <div class="w-fit mx-1 my-0" [title]="checkpointStubStrategy.disabled ? 'This report is in a readonly storage, copy it to the test tab to make changes' : null">
+            <select #checkpointStubStrategy class="form-control" [disabled]="!ReportUtil.isFromCrudStorage(selectedNode)" [(ngModel)]="stub"
+                    (ngModelChange)="updateCheckpointStubStrategy($event)">
               @for (strategy of StubStrategy.checkpoints; track strategy; let index = $index) {
                 <option [ngValue]="index - 1" [selected]="selectedNode.stub === index - 1">{{ strategy }}</option>
               }

--- a/src/app/report/edit-display/edit-display.component.ts
+++ b/src/app/report/edit-display/edit-display.component.ts
@@ -345,7 +345,13 @@ export class EditDisplayComponent implements OnChanges {
       .copyReport(data, 'Test')
       .pipe(catchError(this.errorHandler.handleError()))
       .subscribe({
-        next: () => this.testReportsService.getReports(),
+        next: () => {
+          this.testReportsService.getReports();
+          this.toastService.showSuccess('Copied report to testtab', {
+            buttonText: 'Go to test tab',
+            callback: () => this.router.navigate(['/test']),
+          });
+        },
       }); // TODO: storage is hardcoded, fix issue #196 for this
   }
 
@@ -362,10 +368,6 @@ export class EditDisplayComponent implements OnChanges {
       buttonText: 'Copy to testtab',
       callback: () => {
         this.copyReport();
-        this.toastService.showSuccess('Copied report to testtab', {
-          buttonText: 'Go to test tab',
-          callback: () => this.router.navigate(['/test']),
-        });
       },
     });
     setTimeout(() => {

--- a/src/app/shared/classes/report-hierarchy-transformer.ts
+++ b/src/app/shared/classes/report-hierarchy-transformer.ts
@@ -10,6 +10,7 @@ export class ReportHierarchyTransformer {
   transform(report: Report): Report {
     const checkpoints: Checkpoint[] = report.checkpoints;
     for (const checkpoint of checkpoints) {
+      checkpoint.parentReport = report;
       checkpoint.iconClass = this.getImage(checkpoint.type, checkpoint.encoding ?? '', checkpoint.level);
       if (checkpoint.type === CheckpointType.Startpoint || checkpoint.type === CheckpointType.ThreadStartpoint) {
         this.handleStartpoint(checkpoint);

--- a/src/app/shared/components/toast/toast.component.html
+++ b/src/app/shared/components/toast/toast.component.html
@@ -29,6 +29,9 @@
               <i>Click to see a more detailed description</i>
             </span>
           }
+          @if (toast.toastCallback) {
+            <button class="btn btn-info" (click)="toast.toastCallback.callback()">{{ toast.toastCallback.buttonText }}</button>
+          }
         </div>
       </ngb-toast>
     </div>

--- a/src/app/shared/interfaces/checkpoint.ts
+++ b/src/app/shared/interfaces/checkpoint.ts
@@ -1,4 +1,5 @@
 import { CheckpointType } from '../enums/checkpoint-type';
+import { Report } from './report';
 
 export interface Checkpoint {
   encoding?: string;
@@ -25,4 +26,5 @@ export interface Checkpoint {
   checkpoints?: Checkpoint[];
   icon?: string;
   iconClass?: string;
+  parentReport: Report;
 }

--- a/src/app/shared/interfaces/report.ts
+++ b/src/app/shared/interfaces/report.ts
@@ -3,6 +3,7 @@ import { Checkpoint } from './checkpoint';
 export interface Report {
   checkpoints: Checkpoint[];
   correlationId: string;
+  crudStorage: boolean;
   description: string;
   endTime: number;
   estimatedMemoryUsage: number;

--- a/src/app/shared/interfaces/toast.ts
+++ b/src/app/shared/interfaces/toast.ts
@@ -2,4 +2,10 @@ export interface Toast {
   type: string;
   message: string;
   detailed?: string;
+  toastCallback?: ToastCallback;
+}
+
+export interface ToastCallback {
+  buttonText: string;
+  callback: () => void;
 }

--- a/src/app/shared/services/toast.service.ts
+++ b/src/app/shared/services/toast.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
-import { Toast } from '../interfaces/toast';
+import { Toast, ToastCallback } from '../interfaces/toast';
 
 @Injectable({
   providedIn: 'root',
@@ -12,23 +12,24 @@ export class ToastService {
 
   constructor() {}
 
-  public showDanger(body: string, detailedInfo?: string): void {
+  public showDanger(body: string, detailedInfo?: string, toastCallback?: ToastCallback): void {
     this.toastSubject.next({
       type: 'danger',
       message: body,
       detailed: detailedInfo,
+      toastCallback: toastCallback,
     } as Toast);
   }
 
-  public showWarning(body: string): void {
-    this.toastSubject.next({ type: 'warning', message: body } as Toast);
+  public showWarning(body: string, toastCallback?: ToastCallback): void {
+    this.toastSubject.next({ type: 'warning', message: body, toastCallback: toastCallback } as Toast);
   }
 
-  public showSuccess(body: string): void {
-    this.toastSubject.next({ type: 'success', message: body } as Toast);
+  public showSuccess(body: string, toastCallback?: ToastCallback): void {
+    this.toastSubject.next({ type: 'success', message: body, toastCallback: toastCallback } as Toast);
   }
 
-  public showInfo(body: string): void {
-    this.toastSubject.next({ type: 'info', message: body } as Toast);
+  public showInfo(body: string, toastCallback?: ToastCallback): void {
+    this.toastSubject.next({ type: 'info', message: body, toastCallback: toastCallback } as Toast);
   }
 }

--- a/src/app/shared/util/report-util.ts
+++ b/src/app/shared/util/report-util.ts
@@ -31,4 +31,7 @@ export const ReportUtil = {
   getStorageIdFromUid(uid: string): number {
     return +uid.split('#')[0];
   },
+  isFromCrudStorage(node: Report | Checkpoint): boolean {
+    return ReportUtil.isCheckPoint(node) ? node.parentReport.crudStorage : node.crudStorage;
+  },
 };


### PR DESCRIPTION
Previously reports in the debug tab could be edited in a readonly storage even if the backend did not allow it.
Now when trying to edit a report in the debug tab that is in a read only storage a toast is shown that allows the user to copy to the test tab instead:
![image](https://github.com/user-attachments/assets/b6a7ac4f-ec29-4811-8e1d-e6f9c0ceed34)

After copying the report to the test tab, a new toast appears showing the copy was successfull with a button to go to the test tab:
![image](https://github.com/user-attachments/assets/8b146712-0231-4966-a067-dacea5e83ab5)

Closes #745 