### PR TITLE
fix: rerun report with storage id 0

### DIFF
--- a/src/app/report/edit-display/edit-display.component.ts
+++ b/src/app/report/edit-display/edit-display.component.ts
@@ -144,7 +144,9 @@ export class EditDisplayComponent implements OnChanges {
     } else if (ReportUtil.isCheckPoint(node)) {
       reportId = ReportUtil.getStorageIdFromUid(node.uid);
     }
-    if (reportId) {
+    if (reportId == undefined) {
+      this.toastService.showDanger('Could not find report to rerun');
+    } else {
       this.httpService
         .runReport(this.currentView.storageName, reportId)
         .pipe(catchError(this.errorHandler.handleError()))
@@ -155,8 +157,6 @@ export class EditDisplayComponent implements OnChanges {
             this.debugTab.refreshTable({ displayToast: false });
           },
         });
-    } else {
-      this.toastService.showDanger('Could not find report to rerun');
     }
   }
 


### PR DESCRIPTION
Trying to rerun a report with storage id 0 would give a toast error because in javascript 0 is a falsy value.