### PR TITLE
Fix: message is null when message is empty string

### DIFF
--- a/src/app/report/report-alert-message/report-alert-message.component.html
+++ b/src/app/report/report-alert-message/report-alert-message.component.html
@@ -12,7 +12,7 @@
       </div>
     }
 
-    @if (!report.message) {
+    @if (report.message === null) {
       <div class="btn btn-static px-2">
         Message is null
       </div>


### PR DESCRIPTION
Previously frontend showed both message is null and message is empty string alert for a empty string message:
![image](https://github.com/user-attachments/assets/7f32f23e-3e9c-499b-b21e-4e67f7701de7)

Now it just shows the correct one:
![image](https://github.com/user-attachments/assets/1142a140-29c5-4b38-a487-d5bca6953f12)
![image](https://github.com/user-attachments/assets/7d8ade77-015b-498b-81ab-d4cff786f28b)
