### PR TITLE
Fix: toast messages are no longer hidden behind filter side panel

### DIFF
--- a/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
+++ b/src/app/debug/filter-side-drawer/filter-side-drawer.component.ts
@@ -54,23 +54,22 @@ export class FilterSideDrawerComponent implements OnDestroy, OnInit {
 
   setSubscriptions(): void {
     const showFilterSubscription: Subscription = this.filterService.showFilter$.subscribe({
-      next: (show: boolean) => (this.shouldShowFilter = show),
-      error: () => catchError(this.errorHandler.handleError()),
+      next: (show: boolean) => {
+        this.shouldShowFilter = show;
+        this.filterService.toggleShowFilterSidePanel(show);
+      },
     });
     this.subscriptions.add(showFilterSubscription);
     const metadataLabelsSubscription: Subscription = this.filterService.metadataLabels$.subscribe({
       next: (metadataLabels: string[]) => (this.metadataLabels = metadataLabels),
-      error: () => catchError(this.errorHandler.handleError()),
     });
     this.subscriptions.add(metadataLabelsSubscription);
     const currentRecordSubscription: Subscription = this.filterService.currentRecords$.subscribe({
       next: (records: Map<string, Array<string>>) => (this.currentRecords = records),
-      error: () => catchError(this.errorHandler.handleError()),
     });
     this.subscriptions.add(currentRecordSubscription);
     const metadataTypesSubscription: Subscription = this.filterService.metadataTypes$.subscribe({
       next: (metadataTypes: Map<string, string>) => (this.metadataTypes = metadataTypes),
-      error: () => catchError(this.errorHandler.handleError()),
     });
     this.subscriptions.add(metadataTypesSubscription);
   }

--- a/src/app/debug/filter-side-drawer/filter.service.ts
+++ b/src/app/debug/filter-side-drawer/filter.service.ts
@@ -11,7 +11,9 @@ export class FilterService {
   private currentRecordsSubject: Subject<Map<string, string[]>> = new Subject();
   private metadataTypesSubject: Subject<Map<string, string>> = new Subject();
   private filterErrorSubject: Subject<[boolean, Map<string, string>]> = new Subject();
+  private filterSidePanelVisibleSubject: Subject<boolean> = new Subject<boolean>();
 
+  filterSidePanel$: Observable<boolean> = this.filterSidePanelVisibleSubject.asObservable();
   showFilter$: Observable<boolean> = this.showFilterSubject.asObservable();
   metadataLabels$: Observable<string[]> = this.metadataLabelsSubject.asObservable();
   currentRecords$: Observable<Map<string, string[]>> = this.currentRecordsSubject.asObservable();
@@ -108,5 +110,9 @@ export class FilterService {
   isValidNumber(userInput: string): boolean {
     const regex: RegExp = /^\*?-?\d*(\.\d*)?\*?$/;
     return regex.test(userInput);
+  }
+
+  toggleShowFilterSidePanel(value: boolean) {
+    this.filterSidePanelVisibleSubject.next(value);
   }
 }

--- a/src/app/shared/components/toast/toast.component.css
+++ b/src/app/shared/components/toast/toast.component.css
@@ -9,6 +9,14 @@
   z-index: 999;
 }
 
+.toast-location {
+  right: 5px;
+}
+
+.toast-location-offset {
+  right: 305px;
+}
+
 .close-icon {
   position: absolute;
   right: 0;

--- a/src/app/shared/components/toast/toast.component.html
+++ b/src/app/shared/components/toast/toast.component.html
@@ -1,7 +1,6 @@
-<div class="toast-body">
+<div class="toast-body" [ngClass]="filterPanelVisible ? 'toast-location-offset' : 'toast-location'">
   @for (toast of toasts; track toast) {
     <div class="my-2" [attr.data-cy-toast]="toast.type">
-
       <ngb-toast class="fade animate-show animate-hide position-relative" [ngClass]="'bg-' + toast.type"
                  [autohide]="toast.type !== 'danger'"
                  [delay]="toast.type === 'info' || toast.type ==='success' ? 3000 : toast.type ==='warning' ? 8000 : 0"
@@ -30,9 +29,9 @@
         </div>
         @if (toast.detailed) {
           <span>
-              <br>
-              <i>Click to see a more detailed description</i>
-            </span>
+            <br>
+            <i>Click to see a more detailed description</i>
+          </span>
         }
       </ngb-toast>
     </div>

--- a/src/app/shared/components/toast/toast.component.ts
+++ b/src/app/shared/components/toast/toast.component.ts
@@ -5,6 +5,7 @@ import { ToastService } from '../../services/toast.service';
 import { Subscription } from 'rxjs';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { NgClass } from '@angular/common';
+import { FilterService } from '../../../debug/filter-side-drawer/filter.service';
 
 @Component({
   selector: 'app-toast',
@@ -15,27 +16,32 @@ import { NgClass } from '@angular/common';
 })
 export class ToastComponent implements OnInit, OnDestroy {
   @ViewChild('modal') modal!: TemplateRef<Element>;
-  toastSubscription!: Subscription;
   selected!: Toast;
-
   toasts: Toast[] = [];
   justCopied: boolean = false;
+  filterPanelVisible: boolean = false;
+
+  private subscriptions: Subscription = new Subscription();
 
   constructor(
     private modalService: NgbModal,
     private toastService: ToastService,
+    private filterService: FilterService,
   ) {}
 
   ngOnInit(): void {
-    this.toastSubscription = this.toastService.toastObservable.subscribe((toast: Toast): void => {
+    const toastSubscription = this.toastService.toastObservable.subscribe((toast: Toast): void => {
       this.toasts.push(toast);
     });
+    this.subscriptions.add(toastSubscription);
+    const filterSubscription = this.filterService.filterSidePanel$.subscribe((value) => {
+      this.filterPanelVisible = value;
+    });
+    this.subscriptions.add(filterSubscription);
   }
 
   ngOnDestroy(): void {
-    if (this.toastSubscription) {
-      this.toastSubscription.unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 
   close(alert: Toast): void {


### PR DESCRIPTION
Previously toast messages could be hidden if the filter side panel was opened, like described in #858.
Any toasts are now automatically offset when the filter panel is opened:
![image](https://github.com/user-attachments/assets/fde61d8b-0a8d-4c80-9507-7294ff6bbf2d)
