### PR TITLE
Fix: reports in test tab have null prefixed to path

### DIFF
--- a/src/app/test/test-folder-tree/test-folder-tree.component.ts
+++ b/src/app/test/test-folder-tree/test-folder-tree.component.ts
@@ -43,7 +43,7 @@ export class TestFolderTreeComponent {
 
   convertToTree(data: TestListItem[]): void {
     for (let item of data) {
-      if (item.path) {
+      if (item.path && item.path !== 'null') {
         this.createFolderForRemainingPath(
           item,
           item.path.split('/').filter((s) => s !== ''),

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -300,7 +300,7 @@ export class TestComponent implements OnInit, OnDestroy {
   matches(): void {
     const filteredReports = [];
     for (const report of this.reports) {
-      if (report.path === null) report.path = '';
+      if (report.path === null || report.path === 'null') report.path = '';
       const name: string = report.path + report.name;
       if (new RegExp(`(/)?${this.currentFilter}.*`).test(name)) {
         report.checked = true;


### PR DESCRIPTION
Backend returns null values inside string, causing errors in if conditions.
This is a temporary frontend fix. This should be fixed in the backend.