### PR TITLE
Compare in test tab

### DIFF
--- a/cypress/e2e/no-profile/1-first.spec.ts
+++ b/cypress/e2e/no-profile/1-first.spec.ts
@@ -8,7 +8,7 @@
 describe('Test that should be done before all other tests', () => {
   beforeEach(() => {
     cy.initializeApp();
-    cy.navigateToTestTabAndInterceptApiCall();
+    cy.navigateToTestTabAndAwaitLoadingSpinner();
   })
 
   it('Report in src/test/testtool should not be shown', () => {
@@ -17,4 +17,3 @@ describe('Test that should be done before all other tests', () => {
     cy.getTestTableRows().should('not.exist')
   })
 })
-  

--- a/cypress/e2e/no-profile/test/compare.cy.ts
+++ b/cypress/e2e/no-profile/test/compare.cy.ts
@@ -1,0 +1,55 @@
+describe('Tests for compare button in test tab', () => {
+  beforeEach(() => {
+    cy.createReport();
+    cy.createOtherReport();
+    cy.createJsonReport();
+    cy.initializeApp();
+    cy.copyReportsToTestTab(['Simple report', 'Another simple report', 'Json checkpoint']);
+    cy.navigateToTestTabAndAwaitLoadingSpinner();
+  })
+
+  afterEach(() => {
+    cy.resetApp();
+  })
+
+  it('should show compare button if exactly two reports are selected', () => {
+    selectFirstTwoReportsInTestTab()
+    cy.get('[data-cy-test="compare"]').should('be.visible');
+  });
+
+  it('should not show compare button if one or more than 2 reports are selected', () => {
+    cy.get('[data-cy-test="toggleSelectAll"]').uncheck()
+    cy.get('[data-cy-test="compare"]').should('not.exist');
+    cy.get('[data-cy-test="toggleSelectAll"]').check()
+    cy.get('[data-cy-test="compare"]').should('not.exist');
+  });
+
+  it('should open a compare tab when clicking the compare button in the test tab', () => {
+    selectFirstTwoReportsInTestTab(true)
+    cy.get('[data-cy-nav-tab="Compare"]').should('exist');
+    cy.get('app-compare').should('exist');
+  });
+
+  it('should open the correct reports in compare tab', () => {
+    cy.get('[data-cy-test="settings"]').click();
+    cy.get('[data-cy-test-settings="showStorageIds"]').check();
+    cy.get('[data-cy-test-settings="save"]').click();
+    cy.get('[data-cy-test-table="storageId"]').eq(0).invoke('text').then((firstStorageId) => {
+      cy.get('[data-cy-test-table="storageId"]').eq(1).invoke('text').then((secondStorageId) => {
+        selectFirstTwoReportsInTestTab(true)
+        cy.get('[data-cy-nav-tab="Compare"]').should('exist');
+        cy.get('app-compare').should('exist');
+        cy.url().should('include', firstStorageId).and('include', secondStorageId);
+      });
+    });
+  });
+});
+
+function selectFirstTwoReportsInTestTab(navigateToCompareTab: boolean= false) {
+  cy.get('[data-cy-test="toggleSelectAll"]').uncheck()
+  cy.get('[data-cy-test="selectOne"]').eq(0).check()
+  cy.get('[data-cy-test="selectOne"]').eq(1).check()
+  if (navigateToCompareTab) {
+    cy.get('[data-cy-test="compare"]').click();
+  }
+}

--- a/cypress/e2e/no-profile/test/testtab.cy.ts
+++ b/cypress/e2e/no-profile/test/testtab.cy.ts
@@ -14,7 +14,7 @@ describe('Test the Test tab', () => {
   afterEach(() => cy.resetApp());
 
   it('Should delete one report at a time with deleteSelected button', () => {
-    cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="reportChecked"]').click();
+    cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="selectOne"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableReportsAre(['Simple report']);

--- a/cypress/e2e/no-profile/test/testtab.cy.ts
+++ b/cypress/e2e/no-profile/test/testtab.cy.ts
@@ -13,6 +13,13 @@ describe('Test the Test tab', () => {
 
   afterEach(() => cy.resetApp());
 
+  it('should show storage ids in table when setting is enabled', () => {
+    cy.get('[data-cy-test="settings"]').click();
+    cy.get('[data-cy-test-settings="showStorageIds"]').check();
+    cy.get('[data-cy-test-settings="save"]').click();
+    cy.get('[data-cy-test-table="storageId"]').should('be.visible');
+  });
+
   it('Should delete one report at a time with deleteSelected button', () => {
     cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="selectOne"]').click();
     cy.get('[data-cy-test="deleteSelected"]').click();

--- a/cypress/e2e/no-profile/test/testtab.cy.ts
+++ b/cypress/e2e/no-profile/test/testtab.cy.ts
@@ -8,7 +8,7 @@ describe('Test the Test tab', () => {
     cy.createOtherReport();
     cy.initializeApp();
     copyTheReportsToTestTab();
-    cy.navigateToTestTabAndInterceptApiCall();
+    cy.navigateToTestTabAndAwaitLoadingSpinner();
   });
 
   afterEach(() => cy.resetApp());

--- a/cypress/e2e/storage-xml/1-pre-existing-report.spec.ts
+++ b/cypress/e2e/storage-xml/1-pre-existing-report.spec.ts
@@ -5,7 +5,7 @@
 describe('Pre existing report', () => {
   beforeEach(() => {
     cy.initializeApp();
-    cy.navigateToTestTabAndInterceptApiCall();
+    cy.navigateToTestTabAndAwaitLoadingSpinner();
   })
 
   it('Report present in src/test/testtool should be shown', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -24,9 +24,9 @@ declare global {
 
       clearDatabaseStorage(): Chainable;
 
-      navigateToTestTabAndInterceptApiCall(): Chainable;
+      navigateToTestTabAndAwaitLoadingSpinner(): Chainable;
 
-      navigateToDebugTabAndInterceptApiCall(): Chainable;
+      navigateToDebugTabAndAwaitLoadingSpinner(): Chainable;
 
       navigateToTestTab(): Chainable;
 
@@ -120,14 +120,14 @@ Cypress.Commands.add('clearDatabaseStorage' as keyof Chainable, (): void => {
 })
 
 Cypress.Commands.add(
-  'navigateToTestTabAndInterceptApiCall' as keyof Chainable,
+  'navigateToTestTabAndAwaitLoadingSpinner' as keyof Chainable,
   (): void => {
     navigateToTabAndAwaitLoadingSpinner('test');
   },
 );
 
 Cypress.Commands.add(
-  'navigateToDebugTabAndInterceptApiCall' as keyof Chainable,
+  'navigateToDebugTabAndAwaitLoadingSpinner' as keyof Chainable,
   (): void => {
     navigateToTabAndAwaitLoadingSpinner('debug');
   },

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -48,6 +48,8 @@ declare global {
 
       createReportWithMultipleStartpoints(): Chainable;
 
+      createJsonReport(): Chainable;
+
       clearDebugStore(): Chainable;
 
       clearReportsInProgress(): Chainable;
@@ -85,6 +87,8 @@ declare global {
       selectRowInTestTable(index: number): Chainable;
 
       selectAllRowsInTestTable(): Chainable;
+
+      copyReportsToTestTab(names: string[]): Chainable;
     }
   }
 }
@@ -220,6 +224,18 @@ Cypress.Commands.add(
     // No cy.visit because then the API call can happen multiple times.
     cy.request(
       `${Cypress.env('backendServer')}/index.jsp?createReport=Multiple%20startpoints`,
+    ).then((resp: Cypress.Response<ApiResponse>): void => {
+      expect(resp.status).equal(200);
+    });
+  },
+);
+
+Cypress.Commands.add(
+  'createJsonReport' as keyof Chainable,
+  (): void => {
+    // No cy.visit because then the API call can happen multiple times.
+    cy.request(
+      `${Cypress.env('backendServer')}/index.jsp?createReport=Json%20checkpoint`,
     ).then((resp: Cypress.Response<ApiResponse>): void => {
       expect(resp.status).equal(200);
     });
@@ -371,6 +387,13 @@ Cypress.Commands.add(
     cy.get('[data-cy-test="toggleSelectAll"]').click();
   },
 );
+
+Cypress.Commands.add('copyReportsToTestTab' as keyof Chainable, (names: string[]): Chainable => {
+  for (let name of names) {
+    cy.get('[data-cy-debug="tableRow"]').find(`td:contains(${name})`).click()
+    cy.get('[data-cy-debug-editor="copy"]').click();
+  }
+})
 
 function awaitLoadingSpinner(): void {
   cy.get('[data-cy-loading-spinner]', { timeout: 10000 }).should('not.exist');

--- a/src/app/test/test-settings-modal/test-settings-modal.component.html
+++ b/src/app/test/test-settings-modal/test-settings-modal.component.html
@@ -8,7 +8,7 @@
   <form [formGroup]="settingsForm" (ngSubmit)="saveSettings()">
     <div class="modal-body">
         <div class="form-group form-check-inline">
-          <input class="form-check-input" type="checkbox" formControlName="showReportStorageIds">
+          <input data-cy-test-settings="showStorageIds" class="form-check-input" type="checkbox" formControlName="showReportStorageIds" >
           <label class="form-check-label transform-label">
             Show report storage IDs
           </label>
@@ -22,7 +22,7 @@
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-info" (click)="resetSettings(); modal.dismiss();"><i class="fa fa-undo"></i></button>
-      <button type="submit" class="btn btn-info" (click)="modal.dismiss()"><i class="fa fa-save"></i></button>
+      <button data-cy-test-settings="save" type="submit" class="btn btn-info" (click)="modal.dismiss()"><i class="fa fa-save"></i></button>
     </div>
   </form>
 </ng-template>

--- a/src/app/test/test-table/test-table.component.html
+++ b/src/app/test/test-table/test-table.component.html
@@ -9,7 +9,7 @@
           [checked]="amountOfSelectedReports === reports.length"
           (click)="toggleSelectAll()">
       </th>
-      <td data-cy-test="reportChecked" mat-cell class="table-row-checkbox" *matCellDef="let report">
+      <td mat-cell class="table-row-checkbox" *matCellDef="let report">
         <input type="checkbox" data-cy-test="selectOne" [checked]="report.checked" (click)="toggleCheck(report)">
       </td>
     </ng-container>

--- a/src/app/test/test-table/test-table.component.html
+++ b/src/app/test/test-table/test-table.component.html
@@ -15,7 +15,7 @@
     </ng-container>
     <ng-container matColumnDef="storageId">
       <th mat-header-cell title="Storage Id" *matHeaderCellDef>Storage Id</th>
-      <td mat-cell title="Storage Id" *matCellDef="let report">{{ report.storageId }}</td>
+      <td data-cy-test-table="storageId" mat-cell title="Storage Id" *matCellDef="let report">{{ report.storageId }}</td>
     </ng-container>
     <ng-container matColumnDef="run">
       <th mat-header-cell title="Run/Open" *matHeaderCellDef>(Re)run/open</th>

--- a/src/app/test/test-table/test-table.component.ts
+++ b/src/app/test/test-table/test-table.component.ts
@@ -6,6 +6,7 @@ import {
   OnChanges,
   Output,
   SimpleChanges,
+  AfterContentChecked,
 } from '@angular/core';
 import { TestListItem } from '../../shared/interfaces/test-list-item';
 import { catchError } from 'rxjs';
@@ -51,11 +52,12 @@ import {
   styleUrl: './test-table.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TestTableComponent implements OnChanges {
+export class TestTableComponent implements OnChanges, AfterContentChecked {
   @Input({ required: true }) reports!: TestListItem[];
   @Input() currentFilter: string = '';
   @Input() showStorageIds?: boolean;
   @Output() runEvent: EventEmitter<TestListItem> = new EventEmitter<TestListItem>();
+  @Output() fullyLoaded: EventEmitter<void> = new EventEmitter<void>();
   amountOfSelectedReports: number = 0;
   protected displayedColumns: string[] = [];
 
@@ -83,6 +85,10 @@ export class TestTableComponent implements OnChanges {
       }
       this.getFullPaths();
     }
+  }
+
+  ngAfterContentChecked(): void {
+    this.fullyLoaded.next();
   }
 
   updateDisplayColumn(): void {

--- a/src/app/test/test.component.html
+++ b/src/app/test/test.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="col">
     <div class="buttons pt-1">
-      <div class="buttons button-section">
+      <section class="buttons button-section">
         <p class="button-section-title">General</p>
         <button data-cy-test="refresh" class="btn btn-info" title="Reload test reports"
                 (click)="loadData()"><i class="fa fa-refresh"></i></button>
@@ -16,17 +16,17 @@
           <input #uploadFileTest data-cy-test="uploadFile" type="file" [hidden]="true"
                  (change)="uploadReport($event)">
         </button>
-      </div>
+      </section>
       <span class="button-divider">&#124;</span>
-      <div class="buttons button-section">
+      <section class="buttons button-section">
         <p class="button-section-title">All</p>
         <button class="btn btn-info" title="Reset" (click)="resetRunner()">Reset</button>
         <button data-cy-test="deleteAll" class="btn btn-info" title="Delete all" (click)="openDeleteModal(true)">Delete
           all
         </button>
-      </div>
+      </section>
       <span class="button-divider">&#124;</span>
-      <div class="buttons button-section">
+      <section class="buttons button-section">
         <p class="button-section-title">Selected</p>
         <button data-cy-test="runAll" class="btn btn-info" title="Run selected reports" (click)="runSelected()"><i
           class="fa fa-play"></i></button>
@@ -36,12 +36,18 @@
           <i class="fa fa-copy"></i></button>
         <button data-cy-test="downloadBinary" class="btn btn-info" title="Download binary" (click)="downloadSelected()">
           <i class="fa fa-download"></i></button>
-      </div>
+        @if (childrenLoaded && testTableComponent?.amountOfSelectedReports === 2) {
+          <button data-cy-test="compare" class="btn btn-info" title="Compare two selected reports"
+                  (click)="openCompareTab()">
+            Compare
+          </button>
+        }
+      </section>
       <span class="button-divider">&#124;</span>
-      <div class="buttons button-section">
+      <section class="buttons button-section">
         <p class="button-section-title">One</p>
         <button class="btn btn-info" title="Clone report" (click)="openCloneModal()">Clone</button>
-      </div>
+      </section>
     </div>
 
     <div class="form-group mt-2">
@@ -61,7 +67,8 @@
     } @else {
       <app-test-table
         [reports]="filteredReports" [currentFilter]="currentFilter"
-        [showStorageIds]="showStorageIds" (runEvent)="run($event)">
+        [showStorageIds]="showStorageIds"
+        (fullyLoaded)="childComponentsLoaded()" (runEvent)="run($event)">
       </app-test-table>
     }
   </div>

--- a/src/app/test/test.component.html
+++ b/src/app/test/test.component.html
@@ -8,7 +8,7 @@
         <p class="button-section-title">General</p>
         <button data-cy-test="refresh" class="btn btn-info" title="Reload test reports"
                 (click)="loadData()"><i class="fa fa-refresh"></i></button>
-        <button class="btn btn-info" title="Options" (click)="testSettingsModal.open()"><i class="fa fa-cog"></i>
+        <button data-cy-test="settings" class="btn btn-info" title="Options" (click)="testSettingsModal.open()"><i class="fa fa-cog"></i>
         </button>
         <button data-cy-test="upload" type="button" class="btn btn-info" title="Upload"
                 (click)="uploadFileTest.click()">

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -20,6 +20,9 @@ import { TestReportsService } from './test-reports.service';
 import { TestTableComponent } from './test-table/test-table.component';
 import { DeleteModalComponent } from '../shared/components/delete-modal/delete-modal.component';
 import { LoadingSpinnerComponent } from '../shared/components/loading-spinner/loading-spinner.component';
+import { TabService } from '../shared/services/tab.service';
+import { CompareData } from '../compare/compare-data';
+import { CompareReport } from '../shared/interfaces/compare-reports';
 
 export const updatePathActionConst = ['move', 'copy'] as const;
 export type UpdatePathAction = (typeof updatePathActionConst)[number];
@@ -55,12 +58,13 @@ export class TestComponent implements OnInit, OnDestroy {
   @ViewChild(CloneModalComponent) protected cloneModal!: CloneModalComponent;
   @ViewChild(TestSettingsModalComponent) protected testSettingsModal!: TestSettingsModalComponent;
   @ViewChild(DeleteModalComponent) protected deleteModal!: DeleteModalComponent;
-  @ViewChild(TestFolderTreeComponent) protected testFileTreeComponent!: TestFolderTreeComponent;
-  @ViewChild('moveToInput', { read: NgModel }) protected moveToInputModel!: NgModel;
-  @ViewChild(TestTableComponent) protected testTableComponent!: TestTableComponent;
+  @ViewChild(TestFolderTreeComponent) protected testFileTreeComponent?: TestFolderTreeComponent;
+  @ViewChild('moveToInput', { read: NgModel }) protected moveToInputModel?: NgModel;
+  @ViewChild(TestTableComponent) protected testTableComponent?: TestTableComponent;
 
   private updatePathAction: UpdatePathAction = 'move';
   private testReportServiceSubscription?: Subscription;
+  protected childrenLoaded: boolean = false;
 
   constructor(
     private httpService: HttpService,
@@ -68,6 +72,7 @@ export class TestComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private errorHandler: ErrorHandling,
     protected testReportsService: TestReportsService,
+    private tabService: TabService,
   ) {
     this.getStorageIdsFromLocalStorage();
     this.setGeneratorStatusFromLocalStorage();
@@ -262,7 +267,7 @@ export class TestComponent implements OnInit, OnDestroy {
   updatePath(): void {
     const reportIds: number[] = this.helperService.getSelectedIds(this.filteredReports);
     if (reportIds.length > 0) {
-      const path: string = this.transformPath(this.moveToInputModel.value);
+      const path: string = this.transformPath(this.moveToInputModel?.value);
       const map: UpdatePathSettings = {
         path: path,
         action: this.updatePathAction,
@@ -283,7 +288,7 @@ export class TestComponent implements OnInit, OnDestroy {
   }
 
   changeFilter(filter: string): void {
-    this.currentFilter = filter === this.testFileTreeComponent.rootFolder.path ? '' : this.transformPath(filter);
+    this.currentFilter = filter === this.testFileTreeComponent?.rootFolder.path ? '' : this.transformPath(filter);
     this.matches();
   }
 
@@ -312,5 +317,28 @@ export class TestComponent implements OnInit, OnDestroy {
 
   getSelectedReports(): TestListItem[] {
     return this.filteredReports.filter((item: TestListItem) => item.checked) ?? [];
+  }
+
+  openCompareTab(): void {
+    const checkedReportIds = this.testTableComponent?.reports.filter((r) => r.checked).map((r) => r.storageId);
+    if (checkedReportIds && checkedReportIds.length == 2) {
+      this.httpService
+        .getReports(checkedReportIds, this.testReportsService.storageName)
+        .subscribe((resp: Record<string, CompareReport>) => {
+          const reports: Report[] = Object.values(resp).map((r) => r.report);
+          const compareData: CompareData = {
+            id: this.tabService.createCompareTabId(reports[0], reports[1]),
+            originalReport: reports[0],
+            runResultReport: reports[1],
+          };
+          this.tabService.openNewCompareTab(compareData);
+        });
+    }
+  }
+
+  protected childComponentsLoaded(): void {
+    setTimeout(() => {
+      this.childrenLoaded = true;
+    });
   }
 }


### PR DESCRIPTION
Test tab now has a compare button, located in the `Selected` button section:
![image](https://github.com/user-attachments/assets/71523cbe-4975-4bad-9de8-4c8387412eb6)

Compare button is only visible if exactly 2 reports are selected, just like in the debug tab.
Also added the necessary cypress tests.
Added additional cypress test for the `show storage ids` setting in test tab

Closes #782 