### PR TITLE
Feat: when changing the transformation in the settings reopen any reports directly from the toast

### DIFF
--- a/src/app/debug/debug-tab.service.ts
+++ b/src/app/debug/debug-tab.service.ts
@@ -9,14 +9,12 @@ export class DebugTabService {
   private anyReportsOpen: boolean = false;
 
   private refreshAllSubject: Subject<RefreshCondition | undefined> = new Subject();
-  private refreshTableSubject: Subject<RefreshCondition> = new Subject();
+  private refreshTableSubject: Subject<RefreshCondition | undefined> = new Subject();
   private refreshTreeSubject: Subject<RefreshCondition | undefined> = new Subject();
-  private reopenReportSubject: Subject<void> = new Subject();
 
   refreshAll$: Observable<RefreshCondition | undefined> = this.refreshAllSubject.asObservable();
-  refreshTable$: Observable<RefreshCondition> = this.refreshTableSubject.asObservable();
+  refreshTable$: Observable<RefreshCondition | undefined> = this.refreshTableSubject.asObservable();
   refreshTree$: Observable<RefreshCondition | undefined> = this.refreshTreeSubject.asObservable();
-  reopenReport$: Observable<void> = this.reopenReportSubject.asObservable();
 
   // triggers a refresh that refreshes both the debug table and the debug tree
   refreshAll(condition: RefreshCondition): void {
@@ -25,16 +23,12 @@ export class DebugTabService {
 
   // triggers a refresh that refreshes only the debug table
   refreshTable(condition?: RefreshCondition): void {
-    this.refreshTableSubject.next(condition ?? ({} as RefreshCondition));
+    this.refreshTableSubject.next(condition);
   }
 
   //triggers a refresh that refreshes only the debug tree and the reports in the debug tree where the reportId is present in the argument
-  refreshTree(condition: RefreshCondition | undefined = undefined): void {
+  refreshTree(condition?: RefreshCondition): void {
     this.refreshTreeSubject.next(condition);
-  }
-
-  reopenLastReport(): void {
-    this.reopenReportSubject.next();
   }
 
   hasAnyReportsOpen(): boolean {

--- a/src/app/debug/debug-tab.service.ts
+++ b/src/app/debug/debug-tab.service.ts
@@ -6,13 +6,17 @@ import { RefreshCondition } from '../shared/interfaces/refresh-condition';
   providedIn: 'root',
 })
 export class DebugTabService {
-  private refreshAllSubject: Subject<RefreshCondition> = new Subject();
-  private refreshTableSubject: Subject<RefreshCondition> = new Subject();
-  private refreshTreeSubject: Subject<RefreshCondition> = new Subject();
+  private anyReportsOpen: boolean = false;
 
-  refreshAll$: Observable<RefreshCondition> = this.refreshAllSubject.asObservable();
+  private refreshAllSubject: Subject<RefreshCondition | undefined> = new Subject();
+  private refreshTableSubject: Subject<RefreshCondition> = new Subject();
+  private refreshTreeSubject: Subject<RefreshCondition | undefined> = new Subject();
+  private reopenReportSubject: Subject<void> = new Subject();
+
+  refreshAll$: Observable<RefreshCondition | undefined> = this.refreshAllSubject.asObservable();
   refreshTable$: Observable<RefreshCondition> = this.refreshTableSubject.asObservable();
-  refreshTree$: Observable<RefreshCondition> = this.refreshTreeSubject.asObservable();
+  refreshTree$: Observable<RefreshCondition | undefined> = this.refreshTreeSubject.asObservable();
+  reopenReport$: Observable<void> = this.reopenReportSubject.asObservable();
 
   // triggers a refresh that refreshes both the debug table and the debug tree
   refreshAll(condition: RefreshCondition): void {
@@ -25,7 +29,19 @@ export class DebugTabService {
   }
 
   //triggers a refresh that refreshes only the debug tree and the reports in the debug tree where the reportId is present in the argument
-  refreshTree(condition: RefreshCondition): void {
+  refreshTree(condition: RefreshCondition | undefined = undefined): void {
     this.refreshTreeSubject.next(condition);
+  }
+
+  reopenLastReport(): void {
+    this.reopenReportSubject.next();
+  }
+
+  hasAnyReportsOpen(): boolean {
+    return this.anyReportsOpen;
+  }
+
+  setAnyReportsOpen(open: boolean): void {
+    this.anyReportsOpen = open;
   }
 }

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -70,11 +70,11 @@ export class DebugTreeComponent implements OnDestroy {
       },
     });
     this.subscriptions.add(showMultipleSubscription);
-    const refreshAll: Subscription = this.debugTab.refreshAll$.subscribe((condition: RefreshCondition) =>
+    const refreshAll: Subscription = this.debugTab.refreshAll$.subscribe((condition?: RefreshCondition) =>
       this.refreshReports(condition),
     );
     this.subscriptions.add(refreshAll);
-    const refreshTree: Subscription = this.debugTab.refreshTree$.subscribe((condition: RefreshCondition) =>
+    const refreshTree: Subscription = this.debugTab.refreshTree$.subscribe((condition?: RefreshCondition) =>
       this.refreshReports(condition),
     );
     this.subscriptions.add(refreshTree);
@@ -128,7 +128,7 @@ export class DebugTreeComponent implements OnDestroy {
   }
 
   addReportToTree(report: Report): void {
-    if (this.selectReportIfPresent(report)) {
+    if (this.selectAndReplaceReportIfPresent(report)) {
       return;
     }
     this.lastReport = report;
@@ -170,35 +170,43 @@ export class DebugTreeComponent implements OnDestroy {
     return type === undefined || type === 1 || type === 2;
   }
 
-  selectReportIfPresent(report: Report): boolean {
-    for (let item of this.tree.items) {
-      const treeReport: Report = item.originalValue;
+  selectAndReplaceReportIfPresent(report: Report): boolean {
+    for (let i = 0; i < this.tree.items.length; i++) {
+      const treeReport: Report = this.tree.items[i].originalValue;
       if (treeReport.storageId === report.storageId) {
-        this.tree.selectItem(item.path);
+        const transformedReport = new ReportHierarchyTransformer().transform(report);
+        this.tree.items[i] = this.tree.createItemToFileItem(transformedReport);
+        this.tree.selectItem(this.tree.items[i].path);
         return true;
       }
     }
     return false;
   }
 
-  async refreshReports(condition: RefreshCondition): Promise<void> {
-    const selectedReportId = this.tree.getSelected().originalValue.storageId;
+  async refreshReports(condition?: RefreshCondition): Promise<void> {
+    const selectedReportId: number = this.tree.getSelected().originalValue.storageId;
     let lastSelectedReport: FileTreeItem | undefined;
-    if (condition.reportIds) {
-      for (let i = 0; i < this.tree.items.length; i++) {
-        const report: Report = this.tree.items[i].originalValue as Report;
-        if (condition.reportIds.includes(report.storageId)) {
-          const fileItem: FileTreeItem = await this.getNewReport(report.storageId);
-          if (selectedReportId === report.storageId) {
-            lastSelectedReport = fileItem;
-          }
-          this.tree.items[i] = fileItem;
+
+    const shouldProcessReport = (reportId: number) => !condition?.reportIds || condition.reportIds.includes(reportId);
+
+    for (let i = 0; i < this.tree.items.length; i++) {
+      const report: Report = this.tree.items[i].originalValue as Report;
+
+      if (shouldProcessReport(report.storageId)) {
+        const fileItem: FileTreeItem = await this.getNewReport(report.storageId);
+
+        if (selectedReportId === report.storageId) {
+          lastSelectedReport = fileItem;
         }
-      }
-      if (lastSelectedReport) {
-        this.tree.selectItem(lastSelectedReport.path);
+
+        this.tree.items[i] = fileItem;
       }
     }
+
+    if (lastSelectedReport) {
+      this.tree.selectItem(lastSelectedReport.path);
+    }
+
     this.hideOrShowCheckpointsBasedOnView(this._currentView);
   }
 

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -155,6 +155,7 @@ export class DebugTreeComponent implements OnDestroy {
   }
 
   closeEntireTree(): void {
+    this.debugTab.setAnyReportsOpen(false);
     this.closeEntireTreeEvent.emit();
     this.tree.clearItems();
     this.lastReport = null;

--- a/src/app/debug/debug-tree/debug-tree.component.ts
+++ b/src/app/debug/debug-tree/debug-tree.component.ts
@@ -172,12 +172,12 @@ export class DebugTreeComponent implements OnDestroy {
   }
 
   selectAndReplaceReportIfPresent(report: Report): boolean {
-    for (let i = 0; i < this.tree.items.length; i++) {
-      const treeReport: Report = this.tree.items[i].originalValue;
+    for (const index in this.tree.items) {
+      const treeReport: Report = this.tree.items[index].originalValue;
       if (treeReport.storageId === report.storageId) {
         const transformedReport = new ReportHierarchyTransformer().transform(report);
-        this.tree.items[i] = this.tree.createItemToFileItem(transformedReport);
-        this.tree.selectItem(this.tree.items[i].path);
+        this.tree.items[index] = this.tree.createItemToFileItem(transformedReport);
+        this.tree.selectItem(this.tree.items[index].path);
         return true;
       }
     }
@@ -190,8 +190,8 @@ export class DebugTreeComponent implements OnDestroy {
 
     const shouldProcessReport = (reportId: number) => !condition?.reportIds || condition.reportIds.includes(reportId);
 
-    for (let i = 0; i < this.tree.items.length; i++) {
-      const report: Report = this.tree.items[i].originalValue as Report;
+    for (const index in this.tree.items) {
+      const report: Report = this.tree.items[index].originalValue as Report;
 
       if (shouldProcessReport(report.storageId)) {
         const fileItem: FileTreeItem = await this.getNewReport(report.storageId);
@@ -200,7 +200,7 @@ export class DebugTreeComponent implements OnDestroy {
           lastSelectedReport = fileItem;
         }
 
-        this.tree.items[i] = fileItem;
+        this.tree.items[index] = fileItem;
       }
     }
 

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -161,7 +161,7 @@ export class TableComponent implements OnInit, OnDestroy {
     this.subscriptions.add(filterContextSubscription);
     const refreshAll = this.debugTab.refreshAll$.subscribe((condition?: RefreshCondition) => this.refresh(condition));
     this.subscriptions.add(refreshAll);
-    const refreshTable = this.debugTab.refreshTable$.subscribe((condition: RefreshCondition) =>
+    const refreshTable = this.debugTab.refreshTable$.subscribe((condition?: RefreshCondition) =>
       this.refresh(condition),
     );
     this.subscriptions.add(refreshTable);

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -462,6 +462,7 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   openReport(storageId: number): void {
+    this.debugTab.setAnyReportsOpen(true);
     this.httpService
       .getReport(storageId, this.currentView.storageName)
       .pipe(catchError(this.errorHandler.handleError()))

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -159,7 +159,7 @@ export class TableComponent implements OnInit, OnDestroy {
       error: () => catchError(this.errorHandler.handleError()),
     });
     this.subscriptions.add(filterContextSubscription);
-    const refreshAll = this.debugTab.refreshAll$.subscribe((condition: RefreshCondition) => this.refresh(condition));
+    const refreshAll = this.debugTab.refreshAll$.subscribe((condition?: RefreshCondition) => this.refresh(condition));
     this.subscriptions.add(refreshAll);
     const refreshTable = this.debugTab.refreshTable$.subscribe((condition: RefreshCondition) =>
       this.refresh(condition),
@@ -468,7 +468,6 @@ export class TableComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (data: Report): void => {
           data.storageName = this.currentView.storageName;
-          console.log('opened report from api');
           this.openReportEvent.next(data);
         },
       });

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -603,36 +603,6 @@ export class TableComponent implements OnInit, OnDestroy {
     });
   }
 
-  handleFilterErrorContext(): string {
-    let result: string = '';
-    let moreThanOne: boolean = false;
-    for (const [key, value] of this.filterErrorDetails) {
-      let typeLabel: string = key;
-      switch (typeLabel) {
-        case 'int': {
-          typeLabel = 'number';
-          break;
-        }
-        case 'long': {
-          typeLabel = 'decimal number';
-          break;
-        }
-        case 'timestamp': {
-          typeLabel = 'date time';
-          break;
-        }
-        default: {
-          typeLabel = 'text';
-          break;
-        }
-      }
-      if (moreThanOne) result += ', ';
-      result += `Search value '${value}' is not a valid '${typeLabel}'`;
-      moreThanOne = true;
-    }
-    return result;
-  }
-
   getMetadata(report: Report, field: string): string {
     return report[field as keyof Report];
   }

--- a/src/app/shared/components/toast/toast.component.html
+++ b/src/app/shared/components/toast/toast.component.html
@@ -26,7 +26,7 @@
           }
           <div class="ml-2 mr-4">{{ toast.message }}</div>
           @if (toast.toastCallback) {
-            <button class="btn btn-info" (click)="toast.toastCallback.callback()">{{ toast.toastCallback.buttonText }}</button>
+            <button class="btn btn-info" (click)="executeCallback(toast)">{{ toast.toastCallback.buttonText }}</button>
           }
         </div>
         @if (toast.detailed) {

--- a/src/app/shared/components/toast/toast.component.ts
+++ b/src/app/shared/components/toast/toast.component.ts
@@ -59,4 +59,11 @@ export class ToastComponent implements OnInit, OnDestroy {
       this.justCopied = false;
     }, 2000);
   }
+
+  executeCallback(toast: Toast): void {
+    if (toast.toastCallback) {
+      toast.toastCallback.callback();
+      setTimeout(() => this.close(toast), 500);
+    }
+  }
 }


### PR DESCRIPTION
Previously when changing the transformation in the settings modal a toast would always appear saying you should reopen any open reports to see it with the new transformation.

Now this toast only appears if any reports are opened in the debug tab, and it now has a button to reopen the report directly.
![image](https://github.com/user-attachments/assets/1edcdea9-0668-4f01-acc2-0d96bc72e158)

Closes #713 