### PR TITLE
Fix: show variables in test tab

### DIFF
--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -226,7 +226,7 @@ export class TableComponent implements OnInit, OnDestroy {
     this.loadData();
     this.filterService.setMetadataLabels(this.currentView.metadataNames);
     this.viewChange.next(this.currentView);
-    this.tableSettings.showFilter = !this.tableSettings.showFilter;
+    this.tableSettings.showFilter = false;
     this.filterService.setShowFilter(this.tableSettings.showFilter);
   }
 

--- a/src/app/test/test-reports.service.ts
+++ b/src/app/test/test-reports.service.ts
@@ -11,7 +11,7 @@ export class TestReportsService {
   private testReportsSubject: ReplaySubject<TestListItem[]> = new ReplaySubject<TestListItem[]>(1);
   testReports$: Observable<TestListItem[]> = this.testReportsSubject.asObservable();
   private firstApiCall: boolean = true;
-  metadataNames: string[] = ['storageId', 'name', 'path', 'description'];
+  metadataNames: string[] = ['storageId', 'name', 'path', 'description', 'variableCsv'];
   storageName: string = 'Test';
 
   constructor(

--- a/src/app/test/test-table/test-table.component.html
+++ b/src/app/test/test-table/test-table.component.html
@@ -40,8 +40,8 @@
     <ng-container matColumnDef="variables">
       <th mat-header-cell *matHeaderCellDef>Variables</th>
       <td mat-cell *matCellDef="let report">
-        @if (report.extractedVariables) {
-          <span data-cy-test="variables">{{ report.extractedVariables }}</span>
+        @if (report.variableCsv) {
+          <span data-cy-test="variables">{{ report.variableCsv }}</span>
         }
       </td>
     </ng-container>


### PR DESCRIPTION
Previously variables added to a report were not shown in the test tab.
Now they are:
![image](https://github.com/user-attachments/assets/23dff41e-bfcb-4dbb-ba8a-173646e2edd6)

Closes #764 