### PR TITLE
Fix: auto select reports in testtab

### DIFF
--- a/cypress/e2e/no-profile/keep_state.cy.ts
+++ b/cypress/e2e/no-profile/keep_state.cy.ts
@@ -32,34 +32,14 @@ describe('Tests for keeping state in tabs when switching tabs', () => {
   });
 
   it('should keep the same reports selected in test table', () => {
-    copyToTestTab(0)
-    copyToTestTab(1)
-    cy.intercept({
-      method: 'GET',
-      hostname: 'localhost',
-      url: /\/metadata\/Test\/*?/g,
-    }).as('test-reports');
-    cy.navigateToTestTab()
-    cy.wait('@test-reports').then((result) => {
-      cy.selectAllRowsInTestTable();
-      cy.get('[data-cy-test="selectOne"]').eq(1).click()
-      cy.navigateToDebugTab()
-      cy.navigateToTestTab();
-      cy.get('[data-cy-test="selectOne"]').eq(0).should('not.be.checked')
-      cy.get('[data-cy-test="selectOne"]').eq(1).should('be.checked')
-    })
+    cy.copyReportsToTestTab(['Simple report', 'Another simple report'])
+    cy.navigateToTestTabAndAwaitLoadingSpinner()
+    cy.get('[data-cy-test="toggleSelectAll"]').uncheck();
+    cy.get('[data-cy-test="selectOne"]').eq(1).check()
+    cy.navigateToDebugTab()
+    cy.navigateToTestTab();
+    cy.get('[data-cy-test="selectOne"]').eq(0).should('not.be.checked')
+    cy.get('[data-cy-test="selectOne"]').eq(1).should('be.checked')
   });
 
 });
-
-function copyToTestTab(index: number) {
-  const alias = `copy-report-${index}`
-  cy.intercept({
-    method: 'PUT',
-    hostname: 'localhost',
-    url: /\/report\/store\/*?/g,
-  }).as(alias);
-  cy.clickRowInTable(index)
-  cy.get('[data-cy-debug-editor="copy"]').click()
-  cy.wait(`@${alias}`)
-}

--- a/cypress/e2e/no-profile/test/testtab.cy.ts
+++ b/cypress/e2e/no-profile/test/testtab.cy.ts
@@ -7,7 +7,7 @@ describe('Test the Test tab', () => {
     cy.createReport();
     cy.createOtherReport();
     cy.initializeApp();
-    copyTheReportsToTestTab();
+    cy.copyReportsToTestTab(['Simple report', 'Another simple report'])
     cy.navigateToTestTabAndAwaitLoadingSpinner();
   });
 
@@ -21,25 +21,28 @@ describe('Test the Test tab', () => {
   });
 
   it('Should delete one report at a time with deleteSelected button', () => {
-    cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="selectOne"]').click();
+    cy.getTestTableRows().contains('Another simple report').parent('tr').find('[data-cy-test="selectOne"]').check();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableReportsAre(['Simple report']);
+    cy.getTestTableRows().contains('Simple report').parent('tr').find('[data-cy-test="selectOne"]').check();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
   });
 
   it('Should delete all tests with deleteSelected button', () => {
+    cy.get('[data-cy-test="toggleSelectAll"]').check();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
     cy.checkTestTableNumRows(0);
   });
 
   it('Should not open delete modal when clicking on deleteSelected button and there are no tests selected', () => {
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    cy.get('[data-cy-test="toggleSelectAll"]').uncheck()
     cy.get('[data-cy-test="deleteSelected"]').click();
+    cy.get('[data-cy-delete-modal="confirm"]').should('not.exist');
     cy.checkTestTableNumRows(2);
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
+    cy.get('[data-cy-test="toggleSelectAll"]').check();
     cy.get('[data-cy-test="deleteSelected"]').click();
     cy.get('[data-cy-delete-modal="confirm"]').click();
   });
@@ -68,25 +71,3 @@ describe('Test the Test tab', () => {
     cy.get('[data-cy-test="runResult"]').should('be.visible');
   });
 });
-
-function copyTheReportsToTestTab() {
-  cy.enableShowMultipleInDebugTree();
-  cy.get('[data-cy-debug="selectAll"]').click();
-  cy.get('[data-cy-debug="openSelected"]').click();
-  // We test many times already that opening two reports yields six nodes.
-  // Adding the test here again has another purpose. We want the DOM to
-  // be stable before we go on with the test. Without this guard, the test
-  // was flaky because the selectIfNotSelected() custom command accessed
-  // a detached DOM element.
-
-  cy.checkFileTreeLength(2);
-
-  cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(0).find('.item-name').eq(0).click();
-
-  cy.debugTreeGuardedCopyReport('Simple report', 3, 'first');
-
-  cy.get('[data-cy-debug-tree="root"] > app-tree-item').eq(1).find('.item-name').eq(0).click();
-
-  cy.debugTreeGuardedCopyReport('Another simple report', 3, 'second');
-
-}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -86,8 +86,6 @@ declare global {
 
       selectRowInTestTable(index: number): Chainable;
 
-      selectAllRowsInTestTable(): Chainable;
-
       copyReportsToTestTab(names: string[]): Chainable;
     }
   }
@@ -379,12 +377,6 @@ Cypress.Commands.add(
   'selectRowInTestTable' as keyof Chainable,
   (index: number): Chainable => {
     cy.get('[data-cy-test="selectOne"]').eq(index).click();
-  },
-);
-Cypress.Commands.add(
-  'selectAllRowsInTestTable' as keyof Chainable,
-  (): Chainable => {
-    cy.get('[data-cy-test="toggleSelectAll"]').click();
   },
 );
 

--- a/src/app/test/test-table/test-table.component.html
+++ b/src/app/test/test-table/test-table.component.html
@@ -6,7 +6,8 @@
           data-cy-test="toggleSelectAll"
           type="checkbox"
           title="Select all rows"
-          [checked]="amountOfSelectedReports === reports.length"
+          [checked]="amountOfSelectedReports === reports.length && reports.length !== 0"
+          [disabled]="reports.length === 0"
           (click)="toggleSelectAll()">
       </th>
       <td mat-cell class="table-row-checkbox" *matCellDef="let report">

--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -308,7 +308,6 @@ export class TestComponent implements OnInit, OnDestroy {
       if (report.path === null || report.path === 'null') report.path = '';
       const name: string = report.path + report.name;
       if (new RegExp(`(/)?${this.currentFilter}.*`).test(name)) {
-        report.checked = true;
         filteredReports.push(report);
       }
     }


### PR DESCRIPTION
Previously all reports copied to the testtab would automatically be checked.
This has been disabled as it caused all report checkboxes to be reset after a rerun, see #838.
Select all checkbox is also no longer checked if there are no reports in the table.

Closes #838 