### PR TITLE
Feat: order of selecting reports is saved

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,9 +1,10 @@
-import { NgModule } from '@angular/core';
+import { Injectable, NgModule } from '@angular/core';
 import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy, RouterModule, Routes } from '@angular/router';
 import { DebugComponent } from './debug/debug.component';
 import { TestComponent } from './test/test.component';
 import { CompareComponent } from './compare/compare.component';
 import { ReportComponent } from './report/report.component';
+import { TabService } from './shared/services/tab.service';
 
 export const routes: Routes = [
   {
@@ -36,8 +37,20 @@ export const routes: Routes = [
 })
 export class AppRoutingModule {}
 
+@Injectable({
+  providedIn: 'root',
+})
 export class AppRouteReuseStrategy implements RouteReuseStrategy {
   storedRoutes: { [key: string]: DetachedRouteHandle } = {};
+
+  constructor(private tabService: TabService) {
+    this.tabService.closeTab$.subscribe((closeTab) => {
+      const pathPrefix = closeTab.type === 'report' ? 'report' : 'compare';
+      const routePath = `${pathPrefix}/${closeTab.id}`;
+
+      delete this.storedRoutes[routePath];
+    });
+  }
 
   shouldDetach(route: ActivatedRouteSnapshot): boolean {
     return true;
@@ -45,20 +58,39 @@ export class AppRouteReuseStrategy implements RouteReuseStrategy {
 
   store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void {
     if (route.routeConfig && handle) {
-      this.storedRoutes[route.routeConfig.path || ''] = handle;
+      const path = route.routeConfig.path || '';
+      const id = this.getRouteId(route);
+
+      if (path.startsWith('report') || path.startsWith('compare')) {
+        if (
+          (path.startsWith('report') && this.tabService.activeReportTabs.has(id)) ||
+          (path.startsWith('compare') && this.tabService.activeCompareTabs.has(id))
+        ) {
+          this.storedRoutes[path] = handle;
+        } else {
+          delete this.storedRoutes[path];
+        }
+      } else {
+        this.storedRoutes[path] = handle;
+      }
     }
   }
 
   shouldAttach(route: ActivatedRouteSnapshot): boolean {
-    return !!route.routeConfig && !!this.storedRoutes[route.routeConfig.path || ''];
+    const path = route.routeConfig?.path || '';
+    return !!this.storedRoutes[path];
   }
 
   retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null {
-    if (!route.routeConfig) return null;
-    return this.storedRoutes[route.routeConfig.path || ''];
+    const path = route.routeConfig?.path || '';
+    return this.storedRoutes[path] || null;
   }
 
   shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
     return future.routeConfig === curr.routeConfig;
+  }
+
+  private getRouteId(route: ActivatedRouteSnapshot): string {
+    return route.params['id'] || '';
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,9 +101,9 @@ export class AppComponent implements OnInit, OnDestroy {
       this.tabs.push({
         key: data.report.name,
         id: String(data.report.storageId),
-        data: data.report,
+        data: data,
         path: `report/${data.report.storageId}`,
-      });
+      } as Tab);
     }
 
     this.router.navigate([ReportComponent.ROUTER_PATH, data.report.storageId]);
@@ -119,7 +119,7 @@ export class AppComponent implements OnInit, OnDestroy {
         id: tabId,
         data: data,
         path: `compare/${tabId}`,
-      });
+      } as Tab);
     }
     this.router.navigate([CompareComponent.ROUTER_PATH, tabId]);
   }
@@ -129,6 +129,9 @@ export class AppComponent implements OnInit, OnDestroy {
     this.tabs.splice(index, 1);
     if (this.router.url.includes(tab.path)) {
       this.location.back();
+    }
+    if (tab.data) {
+      this.tabService.closeTab(tab.data);
     }
   }
 

--- a/src/app/debug/table/table.component.html
+++ b/src/app/debug/table/table.component.html
@@ -85,7 +85,7 @@
         </span>
       }
 
-      @switch (amountOfSelectedReports) {
+      @switch (selectedReports.length) {
         @case (1) {
           <button data-cy-debug="openReportTab" class="btn btn-info btn-table" title="Open In New Tab"
                   (click)="openReportInTab()">
@@ -114,7 +114,7 @@
               type="checkbox"
               class="vertical-middle"
               title="Select all rows"
-              [checked]="amountOfSelectedReports === tableSettings.reportMetadata.length && amountOfSelectedReports > 0"
+              [checked]="selectedReports.length === tableSettings.reportMetadata.length && selectedReports.length > 0"
               [style.width]="checkboxSize"
               [style.height]="checkboxSize"
               (click)="toggleSelectAll()">

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -85,7 +85,7 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   protected metadataCount: number = 0;
-  protected amountOfSelectedReports: number = 0;
+  protected selectedReports: Report[] = [];
   protected hasTimedOut: boolean = false;
   protected tableDataSource: MatTableDataSource<Report> = new MatTableDataSource<Report>();
   protected tableSettings: TableSettings = {
@@ -107,6 +107,9 @@ export class TableComponent implements OnInit, OnDestroy {
   protected openInProgress: FormControl = new FormControl(1, this.defaultReportInProgressValidators);
 
   private reportsInProgress: Record<string, number> = {};
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  private selectedReportIds: number[] = this.selectedReports.map((report: Report): number => report.storageId);
 
   private showMultipleFiles?: boolean;
   private tableDataSort?: MatSort;
@@ -305,19 +308,20 @@ export class TableComponent implements OnInit, OnDestroy {
     event.stopPropagation();
     report.checked = !report.checked;
     if (report.checked) {
-      this.amountOfSelectedReports++;
+      this.selectedReports.push(report);
     } else {
-      this.amountOfSelectedReports--;
+      const index = this.selectedReports.indexOf(report);
+      this.selectedReports.splice(index, 1);
     }
   }
 
   toggleSelectAll(): void {
-    if (this.amountOfSelectedReports === this.tableSettings.reportMetadata.length) {
+    if (this.selectedReports.length === this.tableSettings.reportMetadata.length) {
       this.setCheckedForAllReports(false);
-      this.amountOfSelectedReports = 0;
+      this.selectedReports = [];
     } else {
       this.setCheckedForAllReports(true);
-      this.amountOfSelectedReports = this.tableSettings.reportMetadata.length;
+      this.selectedReports = [...this.tableSettings.reportMetadata];
     }
   }
 
@@ -364,21 +368,18 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   openSelected(): void {
-    if (this.amountOfSelectedReports > 1 && !this.showMultipleFiles) {
+    if (this.selectedReports.length > 1 && !this.showMultipleFiles) {
       this.toastService.showWarning(
         'Please enable show multiple files in settings to open multiple files in the debug tree',
       );
       return;
     }
-    const selectedReports: number[] = this.tableSettings.reportMetadata
-      .filter((report: Report) => report.checked)
-      .map((report: Report) => report.storageId);
     this.httpService
-      .getReports(selectedReports, this.currentView.storageName)
+      .getReports(this.selectedReportIds, this.currentView.storageName)
       .pipe(catchError(this.errorHandler.handleError()))
       .subscribe({
         next: (data: Record<string, CompareReport>) => {
-          for (const storageId of selectedReports) {
+          for (const storageId of this.selectedReportIds) {
             this.openReportEvent.next(data[storageId].report);
           }
         },
@@ -415,16 +416,13 @@ export class TableComponent implements OnInit, OnDestroy {
   }
 
   compareTwoReports(): void {
-    const selectedReports: number[] = this.tableSettings.reportMetadata
-      .filter((report) => report.checked)
-      .map((report) => report.storageId);
     this.httpService
-      .getReports(selectedReports, this.currentView.storageName)
+      .getReports(this.selectedReportIds, this.currentView.storageName)
       .pipe(catchError(this.errorHandler.handleError()))
       .subscribe({
         next: (data: Record<string, CompareReport>) => {
-          const originalReport = this.transformCompareToReport(data[selectedReports[0]]);
-          const runResultReport = this.transformCompareToReport(data[selectedReports[1]]);
+          const originalReport = this.transformCompareToReport(data[this.selectedReportIds[0]]);
+          const runResultReport = this.transformCompareToReport(data[this.selectedReportIds[1]]);
 
           const id: string = this.tabService.createCompareTabId(originalReport, runResultReport);
           this.tabService.openNewCompareTab({

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -106,7 +106,6 @@ export class TableComponent implements OnInit, OnDestroy {
   protected checkboxSize?: string;
   protected openInProgress: FormControl = new FormControl(1, this.defaultReportInProgressValidators);
 
-  private filterErrorDetails: Map<string, string> = new Map<string, string>();
   private reportsInProgress: Record<string, number> = {};
 
   private showMultipleFiles?: boolean;

--- a/src/app/debug/table/table.component.ts
+++ b/src/app/debug/table/table.component.ts
@@ -109,7 +109,9 @@ export class TableComponent implements OnInit, OnDestroy {
   private reportsInProgress: Record<string, number> = {};
 
   // eslint-disable-next-line unicorn/consistent-function-scoping
-  private selectedReportIds: number[] = this.selectedReports.map((report: Report): number => report.storageId);
+  private get selectedReportIds(): number[] {
+    return this.selectedReports.map((report: Report): number => report.storageId);
+  }
 
   private showMultipleFiles?: boolean;
   private tableDataSort?: MatSort;

--- a/src/app/shared/directives/copy-tooltip.directive.spec.ts
+++ b/src/app/shared/directives/copy-tooltip.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { By } from '@angular/platform-browser';
@@ -20,15 +20,6 @@ describe('CopyTooltipDirective', () => {
       providers: [Clipboard],
     });
   });
-
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  function setup(value: string) {
-    const fixture = TestBed.createComponent(TestComponent);
-    const component = fixture.componentInstance;
-    component.value = value;
-    fixture.detectChanges();
-    return fixture;
-  }
 
   it('should not show tooltip if value is an empty string', () => {
     const fixture = setup('');
@@ -62,3 +53,11 @@ describe('CopyTooltipDirective', () => {
     }, 2100);
   });
 });
+
+function setup(value: string): ComponentFixture<TestComponent> {
+  const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+  const component: TestComponent = fixture.componentInstance;
+  component.value = value;
+  fixture.detectChanges();
+  return fixture;
+}

--- a/src/app/shared/interfaces/tab.ts
+++ b/src/app/shared/interfaces/tab.ts
@@ -1,9 +1,9 @@
-import { Report } from './report';
 import { CompareData } from '../../compare/compare-data';
+import { ReportData } from './report-data';
 
 export interface Tab {
   key: string;
   id: string;
-  data?: Report | CompareData;
+  data?: ReportData | CompareData;
   path: string;
 }


### PR DESCRIPTION
When selecting reports in the debug table, the order is saved, so that when two reports are compared, the first selected report is always on the left side and the last selected report is always on the right side.

